### PR TITLE
global refactor "Michalis" --> "Michaelis"

### DIFF
--- a/biocrnpyler/mechanisms_enzyme.py
+++ b/biocrnpyler/mechanisms_enzyme.py
@@ -61,8 +61,8 @@ class BasicProduction(Mechanism):
 
         return [Reaction(inputs, outputs, kcat)]
 
-class MichalisMenten(Mechanism):
-    """Mechanism to automatically generate Michalis-Menten Type Reactions
+class MichaelisMenten(Mechanism):
+    """Mechanism to automatically generate Michaelis-Menten Type Reactions
        In the Copy RXN version, the Substrate is not Consumed
        Sub+Enz <--> Sub:Enz --> Enz+Prod
     """
@@ -115,8 +115,8 @@ class MichalisMenten(Mechanism):
         return [binding_rxn, cat_rxn]
 
 
-class MichalisMentenReversible(Mechanism):
-    """Mechanism to automatically generate Michalis-Menten Type Reactions with products that can bind to enzymes
+class MichaelisMentenReversible(Mechanism):
+    """Mechanism to automatically generate Michaelis-Menten Type Reactions with products that can bind to enzymes
        In the Copy RXN version, the Substrate is not Consumed
        Sub+Enz <--> Sub:Enz --> Enz:Prod <--> Enz + Prod
     """
@@ -180,7 +180,7 @@ class MichalisMentenReversible(Mechanism):
         return [binding_rxn1, binding_rxn2, cat_rxn]
 
 
-class MichalisMentenCopy(Mechanism):
+class MichaelisMentenCopy(Mechanism):
     """In the Copy RXN version, the Substrate is not Consumed
        Sub+Enz <--> Sub:Enz --> Sub+Enz+Prod
     """

--- a/biocrnpyler/mechanisms_txtl.py
+++ b/biocrnpyler/mechanisms_txtl.py
@@ -3,8 +3,8 @@ from .chemical_reaction_network import Species, Reaction, ComplexSpecies, Multim
 from .mechanisms_enzyme import *
 
 
-class Transcription_MM(MichalisMentenCopy):
-    """Michalis Menten Transcription
+class Transcription_MM(MichaelisMentenCopy):
+    """Michaelis Menten Transcription
         G + RNAP <--> G:RNAP --> G+RNAP+mRNA
     """
 
@@ -20,7 +20,7 @@ class Transcription_MM(MichalisMentenCopy):
                 "'rnap' parameter must be a string or a Component with defined "
                 "get_species(), or a chemical_reaction_network.Species object")
 
-        MichalisMentenCopy.__init__(self=self, name=name,
+        MichaelisMentenCopy.__init__(self=self, name=name,
                                        mechanism_type="transcription")
 
     def update_species(self, dna, transcript=None, return_rnap=True,
@@ -29,7 +29,7 @@ class Transcription_MM(MichalisMentenCopy):
         if return_rnap:
             species += [self.rnap]
 
-        species += MichalisMentenCopy.update_species(self, self.rnap, dna)
+        species += MichaelisMentenCopy.update_species(self, self.rnap, dna)
         if transcript is None:
             transcript = Species(dna.name, material_type="rna")
 
@@ -51,15 +51,15 @@ class Transcription_MM(MichalisMentenCopy):
         rxns = []
         if transcript is None:
             transcript = Species(dna.name, material_type="rna")
-        rxns += MichalisMentenCopy.update_reactions(self, self.rnap, dna, transcript,
+        rxns += MichaelisMentenCopy.update_reactions(self, self.rnap, dna, transcript,
                                                        complex=complex, kb=kb,
                                                        ku=ku, kcat=ktx)
 
         return rxns
 
 
-class Translation_MM(MichalisMentenCopy):
-    """ Michalis Menten Translation
+class Translation_MM(MichaelisMentenCopy):
+    """ Michaelis Menten Translation
         mRNA + Rib <--> mRNA:Rib --> mRNA + Rib + Protein
     """
 
@@ -74,7 +74,7 @@ class Translation_MM(MichalisMentenCopy):
             raise ValueError(
                 "'ribosome' parameter must be a string, a Component with defined "
                 "get_species, or a chemical_reaction_network.species")
-        MichalisMentenCopy.__init__(self=self, name=name,
+        MichaelisMentenCopy.__init__(self=self, name=name,
                                        mechanism_type="translation")
 
     def update_species(self, transcript, protein=None,
@@ -86,7 +86,7 @@ class Translation_MM(MichalisMentenCopy):
             protein = Species(transcript.name, material_type="protein")
         species += [protein]
 
-        species += MichalisMentenCopy.update_species(self, self.ribosome, transcript)
+        species += MichaelisMentenCopy.update_species(self, self.ribosome, transcript)
 
         return species
 
@@ -104,15 +104,15 @@ class Translation_MM(MichalisMentenCopy):
 
         if protein is None:
             protein = Species(transcript.name, material_type="protein")
-        rxns += MichalisMentenCopy.update_reactions(self, self.ribosome, transcript,
+        rxns += MichaelisMentenCopy.update_reactions(self, self.ribosome, transcript,
                                                        protein, complex=complex,
                                                        kb=kb, ku=ku,
                                                        kcat=ktl)
         return rxns
 
 
-class Degredation_mRNA_MM(MichalisMenten):
-    """Michalis Menten mRNA Degredation by Endonucleases
+class Degredation_mRNA_MM(MichaelisMenten):
+    """Michaelis Menten mRNA Degredation by Endonucleases
        mRNA + Endo <--> mRNA:Endo --> Endo
     """
     def __init__(self, name="rna_degredation_mm", nuclease="RNAase",
@@ -124,14 +124,14 @@ class Degredation_mRNA_MM(MichalisMenten):
         else:
             raise ValueError("'nuclease' parameter requires a "
                              "chemical_reaction_network.species or a string")
-        MichalisMenten.__init__(self=self, name=name,
-                                   mechanism_type="rna_degredation")
+        MichaelisMenten.__init__(self=self, name=name,
+                                 mechanism_type="rna_degredation")
 
     def update_species(self, rna, return_nuclease=True, **keywords):
         species = [rna]
         if return_nuclease:
             species += [self.nuclease]
-        species += MichalisMenten.update_species(self, self.nuclease, rna)
+        species += MichaelisMenten.update_species(self, self.nuclease, rna)
         return species
 
     def update_reactions(self, rna, component, part_id = None, complex=None, **keywords):
@@ -145,7 +145,7 @@ class Degredation_mRNA_MM(MichalisMenten):
         ku = component.get_parameter("ku", part_id = part_id, mechanism = self)
 
         rxns = []
-        rxns += MichalisMenten.update_reactions(self, self.nuclease, rna, Prod=None, complex=complex, kb=kb, ku=ku, kcat=kdeg)
+        rxns += MichaelisMenten.update_reactions(self, self.nuclease, rna, Prod=None, complex=complex, kb=kb, ku=ku, kcat=kdeg)
         return rxns
 
 class SimpleTranscription(Mechanism):

--- a/biocrnpyler/mixtures_cell.py
+++ b/biocrnpyler/mixtures_cell.py
@@ -2,7 +2,7 @@ from warnings import warn
 from warnings import resetwarnings
 from .components_basic import DNA, RNA, Protein, ChemicalComplex
 from .mechanism import EmptyMechanism
-from .mechanisms_enzyme import BasicCatalysis, MichalisMenten
+from .mechanisms_enzyme import BasicCatalysis, MichaelisMenten
 from .mechanisms_binding import One_Step_Binding
 from .mechanisms_txtl import Transcription_MM, Translation_MM, Degredation_mRNA_MM, OneStepGeneExpression, SimpleTranscription, SimpleTranslation
 from .mixture import Mixture
@@ -126,7 +126,7 @@ class TxTlDilutionMixture(Mixture):
         mech_tx = Transcription_MM(rnap = self.rnap.get_species())
         mech_tl = Translation_MM(ribosome = self.ribosome.get_species())
         mech_rna_deg = Degredation_mRNA_MM(nuclease = self.rnaase.get_species())
-        mech_cat = MichalisMenten()
+        mech_cat = MichaelisMenten()
         mech_bind = One_Step_Binding()
 
         default_mechanisms = {

--- a/biocrnpyler/mixtures_extract.py
+++ b/biocrnpyler/mixtures_extract.py
@@ -5,7 +5,7 @@ from warnings import warn
 from warnings import resetwarnings
 from .components_basic import DNA, RNA, Protein, ChemicalComplex
 from .mechanism import EmptyMechanism
-from .mechanisms_enzyme import BasicCatalysis, MichalisMenten
+from .mechanisms_enzyme import BasicCatalysis, MichaelisMenten
 from .mechanisms_binding import One_Step_Binding
 from .mechanisms_txtl import Transcription_MM, Translation_MM, Degredation_mRNA_MM, OneStepGeneExpression, SimpleTranscription, SimpleTranslation
 from .global_mechanism import Dilution
@@ -108,7 +108,7 @@ class TxTlExtract(Mixture):
         mech_tx = Transcription_MM(rnap = self.rnap.get_species())
         mech_tl = Translation_MM(ribosome = self.ribosome.get_species())
         mech_rna_deg = Degredation_mRNA_MM(nuclease = self.rnaase.get_species()) 
-        mech_cat = MichalisMenten()
+        mech_cat = MichaelisMenten()
         mech_bind = One_Step_Binding()
 
 

--- a/biocrnpyler/parameter.py
+++ b/biocrnpyler/parameter.py
@@ -74,7 +74,7 @@ Components and Mixtures can both have one more multiple parameter files by passi
 #### Suppressing warnings
 To suppress parameter warnings, use the keyword parameter_warnings = False inside a Mixture or Component constructor.
 
-Below is an example csv with all the parameters for a tetR promoter undergoing Michalis Menten transcription and translation.
+Below is an example csv with all the parameters for a tetR promoter undergoing Michaelis Menten transcription and translation.
 
 """
 

--- a/examples/2. Compiling CRNs with Enzymes Catalysis and Binding.ipynb
+++ b/examples/2. Compiling CRNs with Enzymes Catalysis and Binding.ipynb
@@ -30,7 +30,7 @@
     "In this context, Enzyme is a Component which looks for a 'catalysis' Mechanism. Two different Mixtures will be compared with different default 'catalysis' Mechanisms.\n",
     "\n",
     "1. Baisc Catalysis: $E + S \\xrightarrow{k_{cat}} E + P$\n",
-    "2. Michalis Menten Catalysis: $E + S \\underset{k_u}{\\overset{k_b}{\\rightleftharpoons}}E:S \\xrightarrow{k_{cat}} E + P$\n",
+    "2. Michaelis Menten Catalysis: $E + S \\underset{k_u}{\\overset{k_b}{\\rightleftharpoons}}E:S \\xrightarrow{k_{cat}} E + P$\n",
     "\n",
     "By default, the Enzyme Component will inherit the Mechanism in its Mixture."
    ]
@@ -80,7 +80,7 @@
     "\n",
     "#Choose a catalysis mechanism by commenting out one of them.\n",
     "mech_cat = BasicCatalysis()\n",
-    "#mech_cat = MichalisMenten()\n",
+    "#mech_cat = MichaelisMenten()\n",
     "\n",
     "#place that mechanism in a dictionary: \"catalysis\":mech_cat\n",
     "default_mechanisms = {mech_cat.mechanism_type:mech_cat}\n",
@@ -161,7 +161,7 @@
     "\n",
     "#creeate a catalysis mechanism. \n",
     "mech_cat = BasicCatalysis()\n",
-    "#mech_cat = MichalisMenten()\n",
+    "#mech_cat = MichaelisMenten()\n",
     "\n",
     "#place that mechanism in a dictionary: \"catalysis\":mech_cat\n",
     "default_mechanisms = {mech_cat.mechanism_type:mech_cat}\n",
@@ -224,7 +224,7 @@
    "source": [
     "#Or specific parameters can be made which give different rates for each enzyme\n",
     "#The first row of parameters is used by BasicCatalysis\n",
-    "#The second-fourth row of parameters is used my MichalisMenten catalysis\n",
+    "#The second-fourth row of parameters is used my MichaelisMenten catalysis\n",
     "specific_parameters = {(\"basic_catalysis\", \"E1\", \"kcat\"):100, (\"basic_catalysis\", \"E2\", \"kcat\"):200, (\"basic_catalysis\", \"E3\", \"kcat\"):300,\n",
     "                       (\"michalis_menten\", \"E1\", \"kb\"):111, (\"michalis_menten\", \"E1\", \"ku\"):11, (\"michalis_menten\", \"E1\", \"kcat\"): 1.11,\n",
     "                       (\"michalis_menten\", \"E2\", \"kb\"):222, (\"michalis_menten\", \"E2\", \"ku\"):22, (\"michalis_menten\", \"E2\", \"kcat\"): 2.22,\n",
@@ -236,7 +236,7 @@
     "\n",
     "#choose a catalysis mechanism. \n",
     "#mech_cat = BasicCatalysis()\n",
-    "mech_cat = MichalisMenten()\n",
+    "mech_cat = MichaelisMenten()\n",
     "\n",
     "#place that mechanism in a dictionary: \"catalysis\":mech_cat\n",
     "default_mechanisms = {mech_cat.mechanism_type:mech_cat}\n",
@@ -254,7 +254,7 @@
     "# Example 4: Adding a Custom Mechanism to a Component\n",
     "Notice that in the above CRN, the enzymatic process is irreversible. However, many biochemists would argue that irreversibility is actually an approximation. In reality, the products of the reaction can bind to the enzyme and, if the chemical potential is high enough, cause the reverse reaction to occur. In many cases, it might be desirable to to only include the reverse reaction for some of the enzymatic reactions being in the Model. In BioCRNpyler, this can be done easily by adding a custom Mechanism to an individual Component which will override the default Mechanism provided by the Mixture.\n",
     "\n",
-    "This is illustrated on the pathway built above, where here Enzyme 3 will be given a new catalysis mechanism called MichalisMentenReversible: $E + S \\rightleftarrows E:S \\rightleftarrows E:P \\rightleftarrows E + P$"
+    "This is illustrated on the pathway built above, where here Enzyme 3 will be given a new catalysis mechanism called MichaelisMentenReversible: $E + S \\rightleftarrows E:S \\rightleftarrows E:P \\rightleftarrows E + P$"
    ]
   },
   {
@@ -293,7 +293,7 @@
     }
    ],
    "source": [
-    "#The MichalisMentenReversible has different parameter names: kb1, ku1, kb2, ku2, and kcat_rev\n",
+    "#The MichaelisMentenReversible has different parameter names: kb1, ku1, kb2, ku2, and kcat_rev\n",
     "default_parameters = {\"kb\":100, \"ku\":10, \"kcat\":1., \"kb1\":111, \"kb2\":22, \"ku1\":11, \"ku2\":22, \"kcat_rev\":.001}\n",
     "\n",
     "#Enzymes 1 and 2 are the same as above\n",
@@ -301,13 +301,13 @@
     "E2 = Enzyme(\"E2\", substrate = \"C\", product = \"D\")\n",
     "\n",
     "#Create a dictionary of custom mechanisms to pass into E3 with the mechanisms keyword\n",
-    "mm_reversible = MichalisMentenReversible()\n",
+    "mm_reversible = MichaelisMentenReversible()\n",
     "custom_mechanisms = {mm_reversible.mechanism_type:mm_reversible}\n",
     "E3 = MultiEnzyme(\"E3\", substrates = [\"B\", \"D\"], products = [\"F\"], mechanisms = custom_mechanisms)\n",
     "\n",
     "#choose a catalysis mechanism. \n",
     "#mech_cat = BasicCatalysis()\n",
-    "mech_cat = MichalisMenten()\n",
+    "mech_cat = MichaelisMenten()\n",
     "#place that mechanism in a dictionary: \"catalysis\":mech_cat\n",
     "default_mechanisms = {mech_cat.mechanism_type:mech_cat}\n",
     "#Make the Mixture\n",
@@ -382,8 +382,8 @@
     "\n",
     "#choose a catalysis mechanism. \n",
     "#mech_cat = BasicCatalysis()\n",
-    "mech_cat = MichalisMenten()\n",
-    "#mech_cat = MichalisMentenReversible()\n",
+    "mech_cat = MichaelisMenten()\n",
+    "#mech_cat = MichaelisMentenReversible()\n",
     "\n",
     "#create a binding mechanism\n",
     "mech_bind = One_Step_Binding() #All species bind together in a single step\n",

--- a/examples/5. Parameters.ipynb
+++ b/examples/5. Parameters.ipynb
@@ -19,7 +19,7 @@
     "#### Suppressing warnings\n",
     "To suppress parameter warnings, use the keyword parameter_warnings = False inside a Mixture or Component constructor.\n",
     "\n",
-    "Below is an example csv with all the parameters for a tetR promoter undergoing Michalis Menten transcription and translation."
+    "Below is an example csv with all the parameters for a tetR promoter undergoing Michaelis Menten transcription and translation."
    ]
   },
   {

--- a/examples/8. Developer Overview.ipynb
+++ b/examples/8. Developer Overview.ipynb
@@ -115,7 +115,7 @@
     "* In update_species, we will create a list of all the species used in the reaction schema: the gene, gene-rnap complex, and the product species.\n",
     "* In update_reactions we create a list of all the reactions required for our reaction schema: the polymerase binding and unbinding reactions as well as the reaction producing the gene product X. \n",
     "\n",
-    "Note that this code could be generated much faster using the built in MichalisMentenRXN Mechanism, but we will do it by hand here for educational purposes."
+    "Note that this code could be generated much faster using the built in MichaelisMentenRXN Mechanism, but we will do it by hand here for educational purposes."
    ]
   },
   {


### PR DESCRIPTION
This is to address #99 , and upon @zoltuz 's request.

**NB** I am not aware of any tests, so non were ran; moreover, my familiarity with this package is limited to the [SBtools June2020 bootcamp](https://www.cds.caltech.edu/~murray/wiki/SBtools_Bootcamp,_June_2020). Therefore, be as suspicious as possible -- things could be broken badly... :-) . 

I ran:
```sed -i 's/Michalis/Michaelis/g' ./biocrnpyler/*``` 
and
```sed -i 's/Michalis/Michaelis/g' ./examples/Parameters\ loading.ipynb```

Verified using:
```grep -rnw './' -e 'Michalis'```
That all strings have been replaced.

Hope that was not too foolish...