### PR TITLE
adding full compatibility with the old Reaction class interface

### DIFF
--- a/Tests/test_reaction.py
+++ b/Tests/test_reaction.py
@@ -98,7 +98,30 @@ def test_old_reaction_interface_massaction():
 
 
 def test_old_reaction_interface_non_massaction():
-    pass
-    A = Species(name="A")
-    #with pytest.raises(NotImplementedError, match='Only massaction kinetic is supported with the old interface'):
-    #    Reaction([], [A, A], k=100, propensity_type='hillpositive')
+    kb = 100
+    ku = 10
+    kex = 1.
+
+    G = Species(name="G", material_type="dna") #DNA
+    A = Species(name="A", material_type="protein") #Activator
+    X = Species(name="X", material_type="protein")
+
+    # hill positive
+    with pytest.deprecated_call():
+        Reaction([G], [G, X], propensity_type="hillpositive",
+                 propensity_params={"k": kex, "n": 2.0, "K": float(kb/ku), "s1": A})
+
+    # proportional hill positive
+    with pytest.deprecated_call():
+        Reaction([G], [G, X], propensity_type="proportionalhillpositive",
+                 propensity_params={"k": kex, "n": 2.0, "K": float(kb/ku), "s1": A, "d": G})
+
+    # hill Negative
+    with pytest.deprecated_call():
+        Reaction([G], [G, X], propensity_type="hillnegative",
+                 propensity_params={"k": kex, "n": 2.0, "K": float(kb/ku), "s1": A})
+
+    # proportional hill negative
+    with pytest.deprecated_call():
+        Reaction([G], [G, X], propensity_type="proportionalhillnegative",
+                 propensity_params={"k": kex, "n": 2.0, "K": float(kb/ku), "s1": A, "d": G})

--- a/biocrnpyler/reaction.py
+++ b/biocrnpyler/reaction.py
@@ -2,7 +2,7 @@
 #  See LICENSE file in the project root directory for details.
 
 from .sbmlutil import *
-from .propensities import Propensity, MassAction, HillNegative
+from .propensities import Propensity, MassAction, HillNegative, HillPositive, ProportionalHillPositive, ProportionalHillNegative
 from.species import *
 import warnings
 import numpy as np
@@ -27,7 +27,7 @@ class Reaction(object):
         if args:
             kwargs['inputs'] = args[0]
             kwargs['outputs'] = args[1]
-        if 'k' in kwargs:
+        if 'k' in kwargs or 'propensity_params' in kwargs:
             self.old_interface(**kwargs)
         else:
             self.new_interface(**kwargs)
@@ -37,11 +37,21 @@ class Reaction(object):
                       rate_formula = None, propensity_params = None):
         warnings.warn('This way to initialize a reaction object is deprecated, please refactor your code!', DeprecationWarning)
 
-        if propensity_type == 'hillpositve':
-            prop_dict = {}
-            prop_dict['parameters'] = propensity_params
-            prop_dict['species'] = {}
-            HillNegative.from_dict(prop_dict)
+        if propensity_type == 'hillpositive':
+            propensity_type = HillPositive(**propensity_params)
+        elif propensity_type == 'hillnegative':
+            propensity_type = HillNegative(**propensity_params)
+        elif propensity_type == 'proportionalhillpositive':
+            propensity_type = ProportionalHillPositive(**propensity_params)
+        elif propensity_type == 'proportionalhillnegative':
+            propensity_type = ProportionalHillNegative(**propensity_params)
+        elif k_rev:
+            propensity_type = MassAction(k_forward=k, k_reverse=k_rev)
+        else:
+            propensity_type = MassAction(k_forward=k)
+
+        if rate_formula is not None:
+            NotImplementedError('General propensity is not supported this way!')
 
         if input_coefs:
             reactants = [WeightedSpecies(species=s, stoichiometry=v) for s,v in zip(inputs, input_coefs, strict=True)]
@@ -53,12 +63,7 @@ class Reaction(object):
         else:
             products = [WeightedSpecies(species=s) for s in outputs]
 
-        if k_rev:
-            mak = MassAction(k_forward=k, k_reverse=k_rev)
-        else:
-            mak = MassAction(k_forward=k)
-
-        self.new_interface(inputs=reactants, outputs=products, propensity_type=mak)
+        self.new_interface(inputs=reactants, outputs=products, propensity_type=propensity_type)
 
     def new_interface(self, inputs: Union[List[Species], List[WeightedSpecies]],
                  outputs: Union[List[Species], List[WeightedSpecies]],


### PR DESCRIPTION
Reaction now workings with Propensity types, but for compatibility reasons, the old (string-based) is supported for now.

- [X] support for all non-massaction types
- [X] unit tests with the old interface format