### PR TITLE
Bug fixes Part 1: Global Mechanisms and Depricate CRN lab

### DIFF
--- a/Tests/test_component.py
+++ b/Tests/test_component.py
@@ -71,6 +71,45 @@ class TestComponent(TestCase):
         # test that the parameter dictionary is still the same length as before
         self.assertTrue(len(self.component.parameter_database.parameters) == len(parameters))
 
+
+    def test_add_mechanism(self):
+        tx = SimpleTranscription()
+        tl = SimpleTranslation()
+
+        #test adding a single mechanism instead of a list still works
+        self.component.add_mechanisms(tx)
+        self.assertTrue(tx.mechanism_type in self.component.mechanisms)
+
+        #add a non-mechanism
+        with self.assertRaisesRegex(TypeError, 'mechanism must be a Mechanism.'):
+            self.component.add_mechanism(None)
+
+        with self.assertRaisesRegex(ValueError, 'add_mechanisms expected a list of Mechanisms.'):
+            self.component.add_mechanisms(None)
+
+        #add same mechanism, new type
+        self.component.add_mechanism(tx, mech_type = "new")
+        self.assertTrue("new" in self.component.mechanisms)
+        self.assertTrue(type(self.component.mechanisms["new"]) == SimpleTranscription)
+
+        #Add invalid mech_type
+        with self.assertRaisesRegex(TypeError, 'mechanism keys must be strings.'):
+            self.component.add_mechanism(tx, mech_type = 1234)
+
+        #add a mechanism already in the Component
+        with self.assertRaisesRegex(ValueError, f"mech_type {tx.mechanism_type} already in component"):
+            self.component.add_mechanism(tx)
+
+        #add mechanism with optional_mechanism - does not overwrite!
+        self.component.add_mechanism(tl, mech_type = tx.mechanism_type, optional_mechanism = True)
+        self.assertTrue(tx.mechanism_type in self.component.mechanisms)
+        self.assertTrue(type(self.component.mechanisms[tx.mechanism_type]) == SimpleTranscription)
+
+        #add mechanism with overwrite
+        self.component.add_mechanism(tl, mech_type = tx.mechanism_type, overwrite = True)
+        self.assertTrue(tx.mechanism_type in self.component.mechanisms)
+        self.assertTrue(type(self.component.mechanisms[tx.mechanism_type]) == SimpleTranslation)
+
     def test_update_mechanisms(self):
 
         tx = SimpleTranscription()

--- a/biocrnpyler/crnlab.py
+++ b/biocrnpyler/crnlab.py
@@ -23,12 +23,18 @@ class CRNLab(object):
         self.crn = None
         self.warning_print = True
 
+        warnings.warn("CRNLab is depricated and will cease to function with future releases.")
+
+
     def mixture(self, name, **kwargs):
         """
         Create a Mixture of a given name into the CRNLab object
         Specify the extract and buffer optionally
         Specify extra parameters to be loaded as dictionaries optionally
         """
+
+        warnings.warn("CRNLab is depricated and will cease to function with future releases: to produce a Mixture please use that Mixture's class constructor.")
+
         extract = kwargs.get('extract') 
         if 'warning_print' in kwargs:
             self.warning_print = kwargs['warning_print']
@@ -67,6 +73,9 @@ class CRNLab(object):
     def add_dna(self, dna = None, name = "", promoter = "", 
                 rbs = "", protein = "", initial_conc ="", 
                 final_conc = "", volume = 0, **kwargs):
+
+        warnings.warn("CRNLab is depricated and will cease to function with future releases: to add DNA to a mixture, please use Mixture.add_component.")
+
         if volume:
             self.volume += volume
         if dna:
@@ -86,6 +95,8 @@ class CRNLab(object):
         return self.Mixture
 
     def add_component(self, component):
+        warnings.warn("CRNLab is depricated and will cease to function with future releases: to add a Component to a mixture, please use Mixture.add_component.")
+
         self.Mixture.add_components(component)
         return self.Mixture
     def set_volumes(self):
@@ -103,10 +114,12 @@ class CRNLab(object):
         else:
             return
     def get_model(self):
+        warnings.warn("CRNLab is depricated and will cease to function with future releases: to generate a CRN model, please use Mixture.combile_crn()")
         self.crn = self.Mixture.compile_crn()
         return self.crn
 
     def write_sbml_file(self, filename, **kwargs):
+        warnings.warn("CRNLab is depricated and will cease to function with future releases: to save a CRN to SBML, please use ChemicalReactionNetwork.write_sbml_file()")
         self.set_volumes()
         if self.volume:
             kwargs['volume'] = self.volume

--- a/biocrnpyler/crnlab.py
+++ b/biocrnpyler/crnlab.py
@@ -23,7 +23,7 @@ class CRNLab(object):
         self.crn = None
         self.warning_print = True
 
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases.", DeprecationWarning)
 
 
     def mixture(self, name, **kwargs):
@@ -33,7 +33,7 @@ class CRNLab(object):
         Specify extra parameters to be loaded as dictionaries optionally
         """
 
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to produce a Mixture please use that Mixture's class constructor.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to produce a Mixture please use that Mixture's class constructor.", DeprecationWarning)
 
         extract = kwargs.get('extract') 
         if 'warning_print' in kwargs:
@@ -74,7 +74,7 @@ class CRNLab(object):
                 rbs = "", protein = "", initial_conc ="", 
                 final_conc = "", volume = 0, **kwargs):
 
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add DNA to a mixture, please use Mixture.add_component.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add DNA to a mixture, please use Mixture.add_component.", DeprecationWarning)
 
         if volume:
             self.volume += volume
@@ -95,7 +95,7 @@ class CRNLab(object):
         return self.Mixture
 
     def add_component(self, component):
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add a Component to a mixture, please use Mixture.add_component.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add a Component to a mixture, please use Mixture.add_component.", DeprecationWarning)
 
         self.Mixture.add_components(component)
         return self.Mixture
@@ -114,12 +114,12 @@ class CRNLab(object):
         else:
             return
     def get_model(self):
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to generate a CRN model, please use Mixture.combile_crn()")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to generate a CRN model, please use Mixture.combile_crn()", DeprecationWarning)
         self.crn = self.Mixture.compile_crn()
         return self.crn
 
     def write_sbml_file(self, filename, **kwargs):
-        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to save a CRN to SBML, please use ChemicalReactionNetwork.write_sbml_file()")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to save a CRN to SBML, please use ChemicalReactionNetwork.write_sbml_file()", DeprecationWarning)
         self.set_volumes()
         if self.volume:
             kwargs['volume'] = self.volume

--- a/biocrnpyler/crnlab.py
+++ b/biocrnpyler/crnlab.py
@@ -23,7 +23,7 @@ class CRNLab(object):
         self.crn = None
         self.warning_print = True
 
-        warnings.warn("CRNLab is depricated and will cease to function with future releases.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases.")
 
 
     def mixture(self, name, **kwargs):
@@ -33,7 +33,7 @@ class CRNLab(object):
         Specify extra parameters to be loaded as dictionaries optionally
         """
 
-        warnings.warn("CRNLab is depricated and will cease to function with future releases: to produce a Mixture please use that Mixture's class constructor.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to produce a Mixture please use that Mixture's class constructor.")
 
         extract = kwargs.get('extract') 
         if 'warning_print' in kwargs:
@@ -74,7 +74,7 @@ class CRNLab(object):
                 rbs = "", protein = "", initial_conc ="", 
                 final_conc = "", volume = 0, **kwargs):
 
-        warnings.warn("CRNLab is depricated and will cease to function with future releases: to add DNA to a mixture, please use Mixture.add_component.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add DNA to a mixture, please use Mixture.add_component.")
 
         if volume:
             self.volume += volume
@@ -95,7 +95,7 @@ class CRNLab(object):
         return self.Mixture
 
     def add_component(self, component):
-        warnings.warn("CRNLab is depricated and will cease to function with future releases: to add a Component to a mixture, please use Mixture.add_component.")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to add a Component to a mixture, please use Mixture.add_component.")
 
         self.Mixture.add_components(component)
         return self.Mixture
@@ -114,12 +114,12 @@ class CRNLab(object):
         else:
             return
     def get_model(self):
-        warnings.warn("CRNLab is depricated and will cease to function with future releases: to generate a CRN model, please use Mixture.combile_crn()")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to generate a CRN model, please use Mixture.combile_crn()")
         self.crn = self.Mixture.compile_crn()
         return self.crn
 
     def write_sbml_file(self, filename, **kwargs):
-        warnings.warn("CRNLab is depricated and will cease to function with future releases: to save a CRN to SBML, please use ChemicalReactionNetwork.write_sbml_file()")
+        warnings.warn("CRNLab is deprecated and will cease to function with future releases: to save a CRN to SBML, please use ChemicalReactionNetwork.write_sbml_file()")
         self.set_volumes()
         if self.volume:
             kwargs['volume'] = self.volume

--- a/biocrnpyler/global_mechanism.py
+++ b/biocrnpyler/global_mechanism.py
@@ -200,15 +200,20 @@ class Degredation_mRNA_MM(GlobalMechanism, MichaelisMenten):
        ComplexSpecies are seperated by this process, including embedded ComplexSpecies. 
        OrderedPolymerSpecies are ignored.
     """
-    def __init__(self, nuclease, name="rna_degredation_mm", mechanism_type = "rna_degredation", **keywords):
+    def __init__(self, nuclease, name="rna_degredation_mm", mechanism_type = "rna_degredation", 
+        default_on = False, recursive_species_filtering = True, filter_dict = None, **keywords):
+
         if isinstance(nuclease, Species):
             self.nuclease = nuclease
         else:
             raise ValueError("'nuclease' must be a Species.")
         MichaelisMenten.__init__(self=self, name=name, mechanism_type = mechanism_type)
 
-        GlobalMechanism.__init__(self, name = name, mechanism_type = mechanism_type, default_on = False,
-                                 filter_dict = {"rna":True, "notdegradable":False}, recursive_species_filtering = True)
+        if filter_dict is None:
+            filter_dict = {"rna":True, "notdegradable":False}
+
+        GlobalMechanism.__init__(self, name = name, mechanism_type = mechanism_type, default_on = default_on,
+                                 filter_dict = filter_dict, recursive_species_filtering = recursive_species_filtering)
 
     def update_species(self, s, mixture):
         species = []
@@ -273,15 +278,19 @@ class Deg_Tagged_Degredation(GlobalMechanism, MichaelisMenten):
        Species_degtagged + protease <--> Species_degtagged:protease --> protease
        All species with the attribute degtagged and material_type protein are degraded. The method is not recursive.
     """
-    def __init__(self, protease, deg_tag = "degtagged", name="deg_tagged_degredation", mechanism_type="degredation", **keywords):
+    def __init__(self, protease, deg_tag = "degtagged", name="deg_tagged_degredation", mechanism_type="degredation", 
+        filter_dict= None, recursive_species_filtering = False, default_on = False, **keywords):
         if isinstance(protease, Species):
             self.protease = protease
         else:
             raise ValueError("'protease' must be a Species.")
         MichaelisMenten.__init__(self=self, name=name, mechanism_type=mechanism_type)
 
-        GlobalMechanism.__init__(self, name = name, mechanism_type = mechanism_type, default_on = False,
-                                 filter_dict = {deg_tag:True}, recursive_species_filtering = False)
+        if filter_dict is None:
+            filter_dict = {deg_tag:True}
+            
+        GlobalMechanism.__init__(self, name = name, mechanism_type = mechanism_type, default_on = default_on,
+                                 filter_dict = filter_dict, recursive_species_filtering = recursive_species_filtering)
 
     def update_species(self, s, mixture):
         species = []

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ minversion = 5.4
 addopts = --nbval-lax --cov=biocrnpyler
 testpaths =
     Tests
-    #examples
+    examples

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ minversion = 5.4
 addopts = --nbval-lax --cov=biocrnpyler
 testpaths =
     Tests
-    examples
+    #examples


### PR DESCRIPTION
This PR fixes issue #173 by adding depricated warnings in most CRNlab functions.

This PR fixes issue #172 by passing through these keywords via the GlobalMechanisms constructors. Unittest were also added.