### PR TITLE
Bug fixes pt2

### DIFF
--- a/Tests/test_parameter.py
+++ b/Tests/test_parameter.py
@@ -29,6 +29,9 @@ class TestParameter(TestCase):
 
         self.assertTrue(Parameter(parameter_name="None", parameter_value="1e2").value == 100)
 
+        self.assertTrue(Parameter(parameter_name="None", parameter_value="1e-2").value == 0.01)
+        self.assertTrue(Parameter(parameter_name="None", parameter_value="2e-2/2").value == 0.01)
+
         # testing invalid parameter name
         with self.assertRaisesRegex(ValueError, f"parameter_name should be at least one character and cannot start with a number!"):
             Parameter(parameter_name="2", parameter_value=2)

--- a/Tests/test_propensities.py
+++ b/Tests/test_propensities.py
@@ -156,6 +156,7 @@ def test_general_propensity():
     assert str(S1) in gn1.propensity_dict['species']
     assert k1.parameter_name in gn1.propensity_dict['parameters']
     assert k2.parameter_name in gn1.propensity_dict['parameters']
+    assert gn1.pretty_print() == 'k1*2 - k2/S1^2\n  k1=1.11\n  k2=2.22\n'
 
     gn2 = GeneralPropensity('S1^2 + S2^2 + S3^2', propensity_species=[S1, S2, S3], propensity_parameters=[])
     assert str(S1) in gn1.propensity_dict['species']

--- a/Tests/test_sbml.py
+++ b/Tests/test_sbml.py
@@ -129,6 +129,10 @@ def test_add_reaction_for_bioscrape():
                 k = k.replace("_reverse", "").replace("_forward", "")
                 check_var = f"{k}=" in sbml_annotation
                 assert  check_var == True
+
+                #be sure that "k=" only shows up once in the annotation
+                assert sbml_annotation.count(f"{k}=") == 1
+                
             for s in prop.propensity_dict["species"]:
                 check_var = f"{s}=" in sbml_annotation
                 assert check_var == True 

--- a/biocrnpyler/parameter.py
+++ b/biocrnpyler/parameter.py
@@ -89,7 +89,7 @@ class Parameter(object):
         if not (isinstance(new_parameter_value, numbers.Real) or isinstance(new_parameter_value, str)):
             raise ValueError(f"parameter_value must be a float or int: received {type(new_parameter_value)}.")
         if isinstance(new_parameter_value, str):
-            if re.search('[a-d-f-z]', new_parameter_value, re.I) \
+            if re.search('[a-df-z]', new_parameter_value, re.I) \
                     or re.search('(^[1-9]+/[1-9]+)|(^[1-9]+e-?[0-9]+)|(^.?[0-9])', new_parameter_value, re.I) is None:
                 raise ValueError(f'No valid parameter value! Accepted formats: 1.00 or 1e4 or 2/5, we got {new_parameter_value} ')
 

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -336,6 +336,7 @@ class MassAction(Propensity):
         # create a kinetic law for the sbml_reaction
         ratelaw = sbml_reaction.createKineticLaw()
 
+
         # translate the internal representation of a propensity to SBML format
         propensity_dict_in_sbml = self._translate_propensity_dict_to_sbml(model=model, ratelaw=ratelaw)
 
@@ -345,8 +346,9 @@ class MassAction(Propensity):
             for w_species in crn_reaction.inputs:
                 species_id = getSpeciesByName(model, str(w_species.species)).getId()
                 reactant_species[species_id] = w_species
-
             param = propensity_dict_in_sbml['parameters']['k_forward']
+            propensity_dict_in_sbml['parameters'].pop('k_reverse', None) #remove the other parameter from the propensities
+            ratelaw.removeLocalParameter("k_reverse") #if k_reverse is a local parameter, remove it
         # set up a reverse reaction
         elif reverse_reaction:
             reactant_species = {}
@@ -354,6 +356,8 @@ class MassAction(Propensity):
                 species_id = getSpeciesByName(model, str(w_species.species)).getId()
                 reactant_species[species_id] = w_species
             param = propensity_dict_in_sbml['parameters']['k_reverse']
+            propensity_dict_in_sbml['parameters'].pop('k_forward', None) #remove the other parameter from the propensities
+            ratelaw.removeLocalParameter("k_forward") #if k_forward is a local parameter, remove it
 
         rate_formula = self._get_rate_formula(param, stochastic, reactant_species)
         # Set the ratelaw to the rateformula

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -255,6 +255,9 @@ class GeneralPropensity(Propensity):
 
         self.name = 'general'
 
+    def pretty_print_rate(self, **kwargs):
+        return self.propensity_function
+
     def create_kinetic_law(self, model, sbml_reaction, **kwargs):
         """Creates KineticLaw object for SBML using the propensity_function string."""
         ratelaw = sbml_reaction.createKineticLaw()


### PR DESCRIPTION
Fixes issue #174 by removing the duplicate parameter from the SBML parameter dictionary and removing local parameters k_foward/k_reverse if they are both created in a non-reversible reaction. Adds new unit tests to find duplicate bioscrape annotations.

Fixes issue #171 as described in that thread by changing the regex expression. Adds new unit tests.

fixes issue #179 by adding GeneralPropensity.pretty_print and an associated unit test.