### PR TITLE
Hill Propensity Local Variable Fix

### DIFF
--- a/Tests/test_propensities.py
+++ b/Tests/test_propensities.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2020, Build-A-Cell. All rights reserved.
 #  See LICENSE file in the project root directory for details.
 
-from biocrnpyler import MassAction, ProportionalHillNegative, ProportionalHillPositive, HillPositive, HillNegative
+from biocrnpyler import MassAction, ProportionalHillNegative, ProportionalHillPositive, HillPositive, HillNegative, Hill
 from biocrnpyler import GeneralPropensity
 from biocrnpyler import ParameterEntry
 from biocrnpyler import Species
@@ -175,3 +175,38 @@ def test_general_propensity():
     test_formula = 'k2*S3^2'
     with pytest.raises(ValueError, match=f'must be part of the formula'):
         GeneralPropensity(test_formula, propensity_species=[S3], propensity_parameters=[k1])
+
+
+def test_propensity_dict_massaction():
+    k1 = ParameterEntry(parameter_value = '1', parameter_name = 'k1')
+    k2 = ParameterEntry(parameter_value = '2', parameter_name = 'k2')
+
+    #Should store the ParameterEntry in this case
+    P1 = MassAction(k_forward = k1, k_reverse = k2)
+    assert P1.propensity_dict["parameters"]["k_forward"] == k1
+    assert P1.propensity_dict["parameters"]["k_reverse"] == k2
+
+    #Should store a numerical value in this case
+    P2 = MassAction(k_forward = k1.value, k_reverse = k2.value)
+    assert P2.propensity_dict["parameters"]["k_forward"] == k1.value
+    assert P2.propensity_dict["parameters"]["k_reverse"] == k2.value
+
+def test_propensity_dict_hill():
+    d = Species('d')
+    s1 = Species('s1')
+    k = ParameterEntry(parameter_value = '1', parameter_name = 'k')
+    K = ParameterEntry(parameter_value = '2', parameter_name = 'K')
+    n = ParameterEntry(parameter_value = '3', parameter_name = 'n')
+
+    #Should store the ParameterEntry in this case
+    P1 = Hill(k = k, K = K, n = n, s1 = s1, d = d)
+    assert P1.propensity_dict["parameters"]["k"] == k
+    assert P1.propensity_dict["parameters"]["K"] == K
+    assert P1.propensity_dict["parameters"]["n"] == n
+
+    #Should store a numerical value in this case
+    P2 = Hill(k = k.value, K = K.value, n = n.value, s1 = s1, d = d)
+    assert P2.propensity_dict["parameters"]["k"] == k.value
+    assert P2.propensity_dict["parameters"]["K"] == K.value
+    assert P2.propensity_dict["parameters"]["n"] == n.value
+

--- a/Tests/test_propensities.py
+++ b/Tests/test_propensities.py
@@ -64,7 +64,7 @@ def test_hill_negative_rate_formula():
     in_n = 2
     philpos = HillNegative(k=in_k, s1=in_s1, K=in_K, n=in_n)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}/(1+({in_s1}/{in_K})^{in_n})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k} / ( 1 + ({in_s1}/{in_K})^{in_n} )"
 
 
 def test_hill_positive_init():
@@ -89,7 +89,7 @@ def test_hill_positive_rate_formula():
     in_n = 2
     philpos = HillPositive(k=in_k, s1=in_s1, K=in_K, n=in_n)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*({in_s1}/{in_K})^{in_n}/(1+({in_s1}/{in_K})^{in_n})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*( {in_s1}/{in_K} )^{in_n} / ( 1 + ({in_s1}/{in_K})^{in_n} )"
 
 
 def test_proportional_hill_positive_init():
@@ -116,7 +116,7 @@ def test_proportional_hill_positive_rate_formula():
     in_n = 2
     philpos = ProportionalHillPositive(k=in_k, s1=in_s1, K=in_K, n=in_n, d=in_d)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*{in_d}*({in_s1}/{in_K})^{in_n}/(1+({in_s1}/{in_K})^{in_n})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*{in_d}*( {in_s1}/{in_K} )^{in_n} / ( 1 + ({in_s1}/{in_K})^{in_n} )"
 
 
 def test_proportional_hill_negative_init():
@@ -143,7 +143,7 @@ def test_proportional_hill_negative_rate_formula():
     in_n = 2
     philneg = ProportionalHillNegative(k=in_k, s1=in_s1, K=in_K, n=in_n, d=in_d)
 
-    assert philneg._get_rate_formula(philneg.propensity_dict) == f"{in_k}*{in_d}/(1+({in_s1}/{in_K})^{in_n})"
+    assert philneg._get_rate_formula(philneg.propensity_dict) == f"{in_k}*{in_d} / ( 1 + ({in_s1}/{in_K})^{in_n} )"
 
 
 def test_general_propensity():

--- a/Tests/test_propensities.py
+++ b/Tests/test_propensities.py
@@ -64,7 +64,7 @@ def test_hill_negative_rate_formula():
     in_n = 2
     philpos = HillNegative(k=in_k, s1=in_s1, K=in_K, n=in_n)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}/({in_s1}^{in_n}+{in_K})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}/(1+({in_s1}/{in_K})^{in_n})"
 
 
 def test_hill_positive_init():
@@ -89,7 +89,7 @@ def test_hill_positive_rate_formula():
     in_n = 2
     philpos = HillPositive(k=in_k, s1=in_s1, K=in_K, n=in_n)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*{in_s1}^{in_n}/({in_s1}^{in_n}+{in_K})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*({in_s1}/{in_K})^{in_n}/(1+({in_s1}/{in_K})^{in_n})"
 
 
 def test_proportional_hill_positive_init():
@@ -116,7 +116,7 @@ def test_proportional_hill_positive_rate_formula():
     in_n = 2
     philpos = ProportionalHillPositive(k=in_k, s1=in_s1, K=in_K, n=in_n, d=in_d)
 
-    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*{in_d}*{in_s1}^{in_n}/({in_s1}^{in_n}+{in_K})"
+    assert philpos._get_rate_formula(philpos.propensity_dict) == f"{in_k}*{in_d}*({in_s1}/{in_K})^{in_n}/(1+({in_s1}/{in_K})^{in_n})"
 
 
 def test_proportional_hill_negative_init():
@@ -143,7 +143,7 @@ def test_proportional_hill_negative_rate_formula():
     in_n = 2
     philneg = ProportionalHillNegative(k=in_k, s1=in_s1, K=in_K, n=in_n, d=in_d)
 
-    assert philneg._get_rate_formula(philneg.propensity_dict) == f"{in_k}*{in_d}/({in_s1}^{in_n}+{in_K})"
+    assert philneg._get_rate_formula(philneg.propensity_dict) == f"{in_k}*{in_d}/(1+({in_s1}/{in_K})^{in_n})"
 
 
 def test_general_propensity():

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -408,7 +408,7 @@ class Hill(Propensity):
     @k.setter
     def k(self, new_k):
         self._k = self._check_parameter(new_k)
-        self.propensity_dict['parameters']['k'] = self.k
+        self.propensity_dict['parameters']['k'] = self._k
 
     @property
     def K(self):
@@ -420,7 +420,7 @@ class Hill(Propensity):
     @K.setter
     def K(self, new_K):
         self._K = self._check_parameter(new_K)
-        self.propensity_dict['parameters']['K'] = self.K
+        self.propensity_dict['parameters']['K'] = self._K
 
     @property
     def n(self):
@@ -431,7 +431,7 @@ class Hill(Propensity):
     @n.setter
     def n(self, new_n):
         self._n = self._check_parameter(new_n)
-        self.propensity_dict['parameters']['n'] = self.n
+        self.propensity_dict['parameters']['n'] = self._n
 
     @property
     def s1(self):
@@ -449,7 +449,7 @@ class Hill(Propensity):
     @d.setter
     def d(self, new_d):
         self._d = self._check_species(new_d, allow_None=True)
-        self.propensity_dict['species']['d'] = self.d
+        self.propensity_dict['species']['d'] = self._d
 
     def pretty_print_rate(self, show_parameters = True, **kwargs):
         raise NotImplementedError("Propensity class Hill is meant to be subclassed: try HillPositive, HillNegative, ProportionalHillPositive, or ProportionalHillNegative.")

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -499,7 +499,7 @@ class HillPositive(Hill):
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}*({s1}/{K})^{n}/(1+({s1}/{K})^{n})"
+        rate_formula = f"{k}*( {s1}/{K})^{n}/( 1+ ({s1}/{K})^{n} )"
         return rate_formula
 
 
@@ -525,7 +525,7 @@ class HillNegative(Hill):
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}/(1+({s1}/{K})^{n})"
+        rate_formula = f"{k}/( 1+ ({s1}/{K})^{n} )"
         return rate_formula
 
 
@@ -553,7 +553,7 @@ class ProportionalHillPositive(HillPositive):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}*({s1}/{K})^{n}/(1+({s1}/{K})^{n})"
+        return f"{k}*{d}*( {s1}/{K} )^{n}/( 1 + ({s1}/{K})^{n} )"
 
 
 class ProportionalHillNegative(HillNegative):
@@ -572,7 +572,7 @@ class ProportionalHillNegative(HillNegative):
         self.name = 'proportionalhillnegative'
 
     def pretty_print_rate(self, show_parameters=True, **kwargs):
-        return f' Kf = k {self.d.pretty_print(**kwargs)} /(1+({self.s1.pretty_print(**kwargs)}/K)^{self.n})'
+        return f' Kf = k {self.d.pretty_print(**kwargs)} /( 1 + ({self.s1.pretty_print(**kwargs)}/K)^{self.n} )'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
@@ -580,4 +580,4 @@ class ProportionalHillNegative(HillNegative):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}/(1+({s1}/{K})^{n})"
+        return f"{k}*{d}/( 1 + ({s1}/{K})^{n} )"

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -492,14 +492,14 @@ class HillPositive(Hill):
         self.name = 'hillpositive'
 
     def pretty_print_rate(self, show_parameters = True, **kwargs):
-        return f' Kf = k {self.s1.pretty_print(**kwargs)}^n / ({self.s1.pretty_print(**kwargs)}^n + K)'
+        return f' Kf = k ({self.s1.pretty_print(**kwargs)}/K)^n / (1+({self.s1.pretty_print(**kwargs)}/K)^n)'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}*{s1}^{n}/({s1}^{n}+{K})"
+        rate_formula = f"{k}*({s1}/{K})^{n}/(1+({s1}/{K})^{n})"
         return rate_formula
 
 
@@ -518,14 +518,14 @@ class HillNegative(Hill):
         self.name = 'hillnegative'
 
     def pretty_print_rate(self, show_parameters = True, **kwargs):
-        return f' Kf = k / ({self.s1.pretty_print(**kwargs)}^n + K)'
+        return f' Kf = k / ((1+{self.s1.pretty_print(**kwargs)}/K)^n)'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}/({s1}^{n}+{K})"
+        rate_formula = f"{k}/(1+({s1}/{K})^{n})"
         return rate_formula
 
 
@@ -545,7 +545,7 @@ class ProportionalHillPositive(HillPositive):
         self.name = 'proportionalhillpositive'
 
     def pretty_print_rate(self, show_parameters = True,  **kwargs):
-        return f' Kf = k {self.d.pretty_print(**kwargs)} {self.s1.pretty_print(**kwargs)}^n/({self.s1.pretty_print(**kwargs)}^n + K)'
+        return f' Kf = k {self.d.pretty_print(**kwargs)} {self.s1.pretty_print(**kwargs)}^n/(1+({self.s1.pretty_print(**kwargs)}/K)^n)'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
@@ -553,7 +553,7 @@ class ProportionalHillPositive(HillPositive):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}*{s1}^{n}/({s1}^{n}+{K})"
+        return f"{k}*{d}*({s1}/{K})^{n}/(1+({s1}/{K})^{n})"
 
 
 class ProportionalHillNegative(HillNegative):
@@ -572,7 +572,7 @@ class ProportionalHillNegative(HillNegative):
         self.name = 'proportionalhillnegative'
 
     def pretty_print_rate(self, show_parameters=True, **kwargs):
-        return f' Kf = k {self.d.pretty_print(**kwargs)} /({self.s1.pretty_print(**kwargs)}^{self.n} + K)'
+        return f' Kf = k {self.d.pretty_print(**kwargs)} /(1+({self.s1.pretty_print(**kwargs)}/K)^{self.n})'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
@@ -580,4 +580,4 @@ class ProportionalHillNegative(HillNegative):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}/({s1}^{n}+{K})"
+        return f"{k}*{d}/(1+({s1}/{K})^{n})"

--- a/biocrnpyler/propensities.py
+++ b/biocrnpyler/propensities.py
@@ -499,7 +499,7 @@ class HillPositive(Hill):
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}*( {s1}/{K})^{n}/( 1+ ({s1}/{K})^{n} )"
+        rate_formula = f"{k}*( {s1}/{K} )^{n} / ( 1 + ({s1}/{K})^{n} )"
         return rate_formula
 
 
@@ -525,7 +525,7 @@ class HillNegative(Hill):
         n = propensity_dict['parameters']['n']
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
-        rate_formula = f"{k}/( 1+ ({s1}/{K})^{n} )"
+        rate_formula = f"{k} / ( 1 + ({s1}/{K})^{n} )"
         return rate_formula
 
 
@@ -553,7 +553,7 @@ class ProportionalHillPositive(HillPositive):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}*( {s1}/{K} )^{n}/( 1 + ({s1}/{K})^{n} )"
+        return f"{k}*{d}*( {s1}/{K} )^{n} / ( 1 + ({s1}/{K})^{n} )"
 
 
 class ProportionalHillNegative(HillNegative):
@@ -572,7 +572,7 @@ class ProportionalHillNegative(HillNegative):
         self.name = 'proportionalhillnegative'
 
     def pretty_print_rate(self, show_parameters=True, **kwargs):
-        return f' Kf = k {self.d.pretty_print(**kwargs)} /( 1 + ({self.s1.pretty_print(**kwargs)}/K)^{self.n} )'
+        return f' Kf = k {self.d.pretty_print(**kwargs)} / ( 1 + ({self.s1.pretty_print(**kwargs)}/K)^{self.n} )'
 
     def _get_rate_formula(self, propensity_dict):
         k = propensity_dict['parameters']['k']
@@ -580,4 +580,4 @@ class ProportionalHillNegative(HillNegative):
         K = propensity_dict['parameters']['K']
         s1 = propensity_dict['species']['s1']
         d = propensity_dict['species']['d']
-        return f"{k}*{d}/( 1 + ({s1}/{K})^{n} )"
+        return f"{k}*{d} / ( 1 + ({s1}/{K})^{n} )"

--- a/biocrnpyler/sbmlutil.py
+++ b/biocrnpyler/sbmlutil.py
@@ -230,9 +230,9 @@ def _create_products(product_list, sbml_reaction, model):
         product.setConstant(False)
 
 def _create_modifiers(crn_reaction, sbml_reaction, model):
-    reactants_list = [i.species.name for i in crn_reaction.inputs]
-    products_list = [i.species.name for i in crn_reaction.outputs]
-    modifier_species = [i.name for i in crn_reaction.propensity_type.propensity_dict['species'].values()]
+    reactants_list = [str(i.species) for i in crn_reaction.inputs]
+    products_list = [str(i.species) for i in crn_reaction.outputs]
+    modifier_species = [str(i) for i in crn_reaction.propensity_type.propensity_dict['species'].values()]
     for modifier_id in modifier_species:
         modifier_id = str(modifier_id)
         if modifier_id not in reactants_list and modifier_id not in products_list:


### PR DESCRIPTION
I think this fixes the problem in #191 - the propensity_dict was being set to the getters instead of the internal variable. This has been fixed for hill propensities.

This PR also changes the functional form of hill functions from k*X^n/(K+X^n)  to K*(X/K)^n/(1+(X/K)^n) in order to match bioscrape. This does mean that some old values of K are now equivalent to K^(1/n). However, any simulations which were previously conducted via bioscrape will remain unchanged because the old functional form was not being used directly.