### PR TITLE
refactoring roadrunner interface

### DIFF
--- a/Tests/test_simulation_packages_import.py
+++ b/Tests/test_simulation_packages_import.py
@@ -54,12 +54,12 @@ def test_bioscrape_import_simulate_via_sbml():
 
 def test_libroadrunner_import():
     from biocrnpyler import ChemicalReactionNetwork
+    CRN = ChemicalReactionNetwork(species=[], reactions=[])
     try:
-        import numpy as np
-
-        CRN = ChemicalReactionNetwork(species=[],reactions=[])
+        import roadrunner
+    except ModuleNotFoundError:
         with pytest.warns(None) as record:
-            sim_results = CRN.runsim_roadrunner(timepoints=np.linspace(0, 10, 100), filename=None)
+            sim_results = CRN.simulate_with_roadrunner(timepoints=list(range(0,10)))
 
         assert sim_results is None
 
@@ -67,7 +67,10 @@ def test_libroadrunner_import():
         assert len(record) == 1
         # check the warning message
         assert str(record[0].message) == "libroadrunner was not found, please install libroadrunner"
-    except ModuleNotFoundError:
-        print('test skipped')
+    else:
+        sim_results = CRN.simulate_with_roadrunner(timepoints=list(range(0,10)))
+        assert sim_results is not None
+
+
 
 

--- a/Tests/test_simulation_packages_import.py
+++ b/Tests/test_simulation_packages_import.py
@@ -58,16 +58,11 @@ def test_libroadrunner_import():
     try:
         import roadrunner
     except ModuleNotFoundError:
-        with pytest.warns(None) as record:
-            sim_results = CRN.simulate_with_roadrunner(timepoints=list(range(0,10)))
-
-        assert sim_results is None
-
-        # only one warning was triggered
-        assert len(record) == 1
-        # check the warning message
-        assert str(record[0].message) == "libroadrunner was not found, please install libroadrunner"
+        # libroadrunner is not installed, let's check if it triggers a warning inside simulate_with_roadrunner()
+        with pytest.warns(UserWarning, match='libroadrunner was not found, please install libroadrunner'):
+            CRN.simulate_with_roadrunner(timepoints=list(range(0,10)))
     else:
+        # no exception was triggered, we can simulate the CRN with roadrunner
         sim_results = CRN.simulate_with_roadrunner(timepoints=list(range(0,10)))
         assert sim_results is not None
 

--- a/biocrnpyler/chemical_reaction_network.py
+++ b/biocrnpyler/chemical_reaction_network.py
@@ -289,13 +289,13 @@ class ChemicalReactionNetwork(object):
         else:
             return result
 
-    def runsim_roadrunner(self, timepoints, filename, species_to_plot = None):
+    def simulate_with_roadrunner(self, timepoints: List[float], initial_condition_dict: Dict[str,float]=None, return_roadrunner=False):
         """To simulate using roadrunner.
         Arguments:
-        timepoints: The array of time points to run the simulation for. 
-        filename: Name of the SBML file to simulate
+        timepoints: The array of time points to run the simulation for.
+        initial_condition_dict:
 
-        Returns the results array as returned by RoadRunner.
+        Returns the results array as returned by RoadRunner OR a Roadrunner model object.
 
         Refer to the libRoadRunner simulator library documentation 
         for details on simulation results: (http://libroadrunner.org/)[http://libroadrunner.org/]
@@ -304,10 +304,23 @@ class ChemicalReactionNetwork(object):
         res_ar = None
         try:
             import roadrunner
-            rr = roadrunner.RoadRunner(filename)
-            result = rr.simulate(timepoints[0],timepoints[-1],len(timepoints))
-            # TODO fix roadrunner output
-            res_ar = result
+            import io
+            document, _ = self.generate_sbml_model(stochastic_model=False)
+            sbml_string = libsbml.writeSBMLToString(document)
+            # write the sbml_string into a temporary file in memory instead of a file
+            string_out = io.StringIO()
+            string_out.write(sbml_string)
+            # use the temporary file in memory to load the model into libroadrunner
+            rr = roadrunner.RoadRunner(string_out.getvalue())
+            if initial_condition_dict:
+                for species, value in initial_condition_dict.items():
+                    rr.model[f"init([{species}])"] = value
+
+            if return_roadrunner:
+                return rr
+            else:
+                result = rr.simulate(timepoints[0], timepoints[-1], len(timepoints))
+                res_ar = result
         except ModuleNotFoundError:
             warnings.warn('libroadrunner was not found, please install libroadrunner')
         return res_ar

--- a/examples/roadrunner_example.ipynb
+++ b/examples/roadrunner_example.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Import everything from biocrnpyler\n",
+    "from biocrnpyler import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Species can be printed to show their string representation: m1_A_attribute m1_B m2_B D\n",
+      "\n",
+      "Reactions can be printed as well:\n",
+      " m1[A(attribute)] --> 2m1[B] \n",
+      " m1[B] --> m2[B]+D\n",
+      "\n",
+      "Directly printing a CRN shows the string representation of the species used in BioCRNpyler:\n",
+      "Species = m1_A_attribute, m1_B, m2_B, D\n",
+      "Reactions = [\n",
+      "\tm1[A(attribute)] --> 2m1[B]\n",
+      "\tm1[B] --> m2[B]+D\n",
+      "]\n",
+      "\n",
+      "CRN.pretty_print(...) is a function that prints a more customizable version of the CRN, but doesn't show the proper string representation of species.\n",
+      "Species (4) = {0. m1[A(attribute)] init_conc = 0, 1. m1[B] init_conc = 0, 2. m2[B] init_conc = 0, 3. D init_conc = 0}\n",
+      "\n",
+      "Reactions (2) = [\n",
+      "0. m1[A(attribute)] --> 2m1[B]\n",
+      " Kf=k_forward * m1_A_attribute\n",
+      "  k_forward=3.0\n",
+      "\n",
+      "1. m1[B] --> m2[B]+D\n",
+      " Kf=k_forward * m1_B\n",
+      "  k_forward=1.4\n",
+      "\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Example: Model the CRN consisting of: A --> 2B, 2B <--> B + C where C has the same name as B but a new material\n",
+    "A = Species(\"A\", material_type = \"m1\", attributes = [\"attribute\"])\n",
+    "B = Species(\"B\", material_type = \"m1\")\n",
+    "C = Species(\"B\", material_type = \"m2\")\n",
+    "D = Species(\"D\")\n",
+    "\n",
+    "print(\"Species can be printed to show their string representation:\", A, B, C, D)\n",
+    "\n",
+    "#Reaction Rates\n",
+    "k1 = 3.\n",
+    "k2 = 1.4\n",
+    "k2rev = 0.15\n",
+    "\n",
+    "#Reaciton Objects\n",
+    "R1 = Reaction.from_massaction([A], [B, B], k_forward = k1)\n",
+    "R2 = Reaction.from_massaction([B], [C, D], k_forward = k2)\n",
+    "\n",
+    "print(\"\\nReactions can be printed as well:\\n\", R1,\"\\n\", R2)\n",
+    "\n",
+    "#Make a CRN\n",
+    "CRN = ChemicalReactionNetwork(species = [A, B, C, D], reactions = [R1, R2])\n",
+    "\n",
+    "#CRNs can be printed in two different ways\n",
+    "print(\"\\nDirectly printing a CRN shows the string representation of the species used in BioCRNpyler:\")\n",
+    "print(CRN)\n",
+    "\n",
+    "print(\"\\nCRN.pretty_print(...) is a function that prints a more customizable version of the CRN, but doesn't show the proper string representation of species.\")\n",
+    "print(CRN.pretty_print(show_materials = True, show_rates = True, show_attributes = True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The compiled network can be simulated with roadrunner. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEJCAYAAAB7UTvrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhIUlEQVR4nO3de3SU933n8fdXN0BICAkJGF1AmLswEk6I49hxktZ2EsdQuzltNj6bxO3mrHsap3V62t3j9HR3u7vNbtpt0m1225w6TVJnN5s0bdLW4Diu4/jUdnwFG8QdBAiELqALkhACXb/7xzzIwkhiJOaZZ0b6vM6Zo5nfPJePxma+en7P7/k95u6IiIgAZEUdQERE0oeKgoiIjFFREBGRMSoKIiIyRkVBRETGqCiIiMiY0IqCmVWZ2fNmdtDMDpjZo0H7H5pZs5ntCR4fG7fOF82swcyOmNlHwsomIiITs7CuUzCzGBBz9zfNrBDYDTwAfALoc/c/fcfyNcD3gFuBcuCnwDp3HwkloIiIXCMnrA27eyvQGjy/YGaHgIopVrkf+L67DwAnzayBeIF4ZbIVSktLvbq6OnmhRUTmgN27d3e4e9lE74VWFMYzs2rgFuA14A7g82b2GWAX8Lvufp54wXh13GpnmLqIUF1dza5du0LJLCIyW5nZqcneC/1Es5kVAD8EvuDuvcDXgdXAFuJHEl+Z5vYeNrNdZrarvb092XFFROa0UIuCmeUSLwjfdfcfAbj7WXcfcfdR4BvEu4gAmoGqcatXBm1XcffH3X2ru28tK5vw6EdERGYozNFHBnwTOOTuXx3XHhu32C8D+4PnTwKfNLN5ZrYKWAu8HlY+ERG5VpjnFO4APg3sM7M9QdvvAw+a2RbAgUbgNwDc/YCZ/QA4CAwDj2jkkYhIaoU5+uglwCZ468dTrPMl4EthZRIRkanpimYRERmjoiAiImNScp2CTKzp6G72PfE18NGoo4hIhil9753cev/DSd+uikKE9v6vP2L1s4dRSRCR6WocGgYVhdklt7GFMysXcs8zuipbRKZnU0jb1TmFCC1uucDAiqVRxxARGaOiEJH25gYWXXRy16yOOoqIyBgVhYic2vMiACU1dREnERF5m4pCRLoO7QVg5ZY7I04iIvI2FYWIDB5roG+BUVqxNuooIiJjVBQikneqja7yArKy9J9ARNKHvpEiMDo6ypLWiwytXB51FBGRq6goRKDt5H7yB2De2nVRRxERuYqKQgSa6l8GoHTTLREnERG5mopCBM4fjI88qtbIIxFJMyoKERg+foLuwiyKl66IOoqIyFVUFCKw4HQ7PeWLoo4hInINFYUUGxkZZknbJYZXVUQdRUTkGioKKXbmyG7mDUP+uvVRRxERuYaKQoqdCUYelW3aGnESEZFrqSikWO/h/QCs0sgjEUlDKgopNnq8kc7ibAqKSqOOIiJyDRWFFMtv6qS3ojjqGCIiE1JRSKHBgX5Kzw3gqyqjjiIiMiEVhRQ6ffA1ckZh4YaNUUcREZmQikIKtex7FYBlm94TcRIRkYmpKKRQ3+GDjBpU194RdRQRkQmpKKTSidN0lOayIF9TXIhIelJRSKGCM+fpqyyJOoaIyKRUFFKkv6+bJZ1D2E2aGVVE0peKQoqc2vdzshwK1m+KOoqIyKRUFFLk7P43ACjf/N6Ik4iITC60omBmVWb2vJkdNLMDZvZo0F5iZs+a2bHgZ3HQbmb2NTNrMLN6M3tXWNmicPHIIYayYUXNrVFHERGZVJhHCsPA77p7DXAb8IiZ1QCPAc+5+1rgueA1wL3A2uDxMPD1ELOlXFZjMx1L55E3Lz/qKCIikwqtKLh7q7u/GTy/ABwCKoD7gSeCxZ4AHgie3w98x+NeBRabWSysfKm26Ew3/VWaBE9E0ltKzimYWTVwC/AasMzdW4O32oBlwfMKoGncameCtozX29VGSfcI2TdVRx1FRGRKoRcFMysAfgh8wd17x7/n7g74NLf3sJntMrNd7e3tSUwansb6lwAo2rg54iQiIlMLtSiYWS7xgvBdd/9R0Hz2SrdQ8PNc0N4MVI1bvTJou4q7P+7uW919a1lZWXjhk6h9/24AKmrfF3ESEZGphTn6yIBvAofc/avj3noSeCh4/hDwT+PaPxOMQroN6BnXzZTRLh07ykAuVK6bVQOqRGQWyglx23cAnwb2mdmeoO33gS8DPzCzzwKngE8E7/0Y+BjQAPQDvx5itpTKaWyhY9kCsrPD/LhFRG5caN9S7v4SYJO8fdcEyzvwSFh5orS4uZeO2qrrLygiEjFd0RyyrrZTFPWNkrv2pqijiIhcl4pCyBr3vghA8ca6iJOIiFyfikLIOg+8BUBVnW6sIyLpT0UhZAMNx+ifZyxbWRN1FBGR61JRCFleYxud5QvJytJHLSLpT99UIRodHaWkpY/BlcujjiIikhAVhRC1Nx1h4WUnb+2aqKOIiCRERSFEp/bG5zwqrbkl4iQiIolRUQjR+YN7AVihkUcikiFUFEI01HCc3oVGafnqqKOIiCRERSFE80+f43z5oqhjiIgkTEUhJCMjw5S09TO8qjzqKCIiCVNRCEnL8b0sGIQFa9dFHUVEJGEqCiE5s/dlAEprdA8FEckcKgoh6T5UD0D1ljsjTiIikjgVhZCMHG+kqyiboiWxqKOIiCRMRSEk+U0d9FYURR1DRGRaVBRCMDR4mSVnLzO6qjLqKCIi06KiEILTh98gbwTy162POoqIyLSoKISgtf5VAJbevDXiJCIi06OiEILewwcYBapr3x91FBGRaVFRCIGfOEXnkhwWFpZEHUVEZFpUFEKw8EwXfRXFUccQEZk2FYUkG7jUR2n7IH5TVdRRRESmTUUhyU7u+znZDoXrN0UdRURk2lQUkqxt3+sALN98a8RJRESmT0UhyS4ePcxwFlRvuj3qKCIi06aikGR28jSdpXnkLciPOoqIyLSpKCRZ4ZluLlYtiTqGiMiM5CS6oJlVACvHr+PuL4QRKlP19XRS2jXMhbtXRh1FRGRGEioKZvbHwL8CDgIjQbMDKgrjNNa/SDZQtGFz1FFERGYk0SOFB4D17j4QYpaMd+7AbmJAee1tUUcREZmRRM8pnABywwwyG1w6cpjBHKhar4nwRCQzJVoU+oE9ZvZXZva1K4+pVjCzb5nZOTPbP67tD82s2cz2BI+PjXvvi2bWYGZHzOwjM/t1opXV2EzHsvnk5OZFHUVEZEYS7T56MnhMx98A/xv4zjva/8zd/3R8g5nVAJ8ENgHlwE/NbJ27j5BBipp76KqpiDqGiMiMJVQU3P0JM8sD1gVNR9x96DrrvGBm1QnmuB/4fnDO4qSZNQC3Aq8kuH7kujuaKe4dpXfNqqijiIjMWELdR2b2IeAY8BfAXwJHzewDM9zn582sPuheujKVaAXQNG6ZM0HbRFkeNrNdZrarvb19hhGSr3HviwAs3lgbcRIRkZlL9JzCV4APu/sH3f0DwEeAP5vB/r4OrAa2AK3BdqfF3R93963uvrWsrGwGEcLRsX83AJW1mt5CRDJXokUh192PXHnh7keZwWgkdz/r7iPuPgp8g3gXEUAzMH6u6cqgLWNcPnaMS3lQvrou6igiIjOWaFHYZWZ/bWYfCh7fAHZNd2dmFhv38peBKyOTngQ+aWbzzGwVsBZ4fbrbj1JuYyudsYVkZWnmEBHJXImOPvpN4BHgt4PXLxI/tzApM/se8CGg1MzOAP8J+JCZbSF+NXQj8BsA7n7AzH5A/IrpYeCRTBt5VNxygXNbdZJZRDJboqOPBoCvBo+EuPuDEzR/c4rlvwR8KdHtp5P25gYK+53uNaujjiIickOmLApm9gN3/4SZ7SP+1/1V3F1DbYBTe15kIVCskUcikuGud6TwaPBzW9hBMlnXwT0sBFZuuTPqKCIiN2TKs6Lu3ho8/Zy7nxr/AD4XfrzMMHisgb4FRmnF2qijiIjckESHytwzQdu9yQySyeadPktXeYFGHolIxpvyW8zMfjM4n7A+uAr5yuMkUJ+aiOltdHSUktaLDFXHrr+wiEiau945hf8HPA38d+Cxce0X3L0rtFQZpO3kfvIHYN4adR2JSOabsii4ew/QAzwIYGZLgflAgZkVuPvp8COmt9N7X6IIKN10S9RRRERuWKIT4m03s2PASeBfiF949nSIuTJG96F4L1q1Rh6JyCyQ6JnRPwJuA466+yrgLuDV0FJlkOGGk3QXZlG8dEXUUUREbliiRWHI3TuBLDPLcvfnAd1zEljQ1E5PRVHUMUREkiLRuY+6zawAeAH4rpmdAy6GFyszDA8NsqTtEmfuvinqKCIiSZHokcL9xO/T/DvAT4DjwPawQmWKM0d3M28Y8tetjzqKiEhSXPdIwcyygZ3u/gvAKPBE6KkyRHP9K5QAZZvUkyYis8N1jxSCKaxHzUwd5+/Qeyh+O4hVGnkkIrNEoucU+oB9ZvYs484luPtvT77K7Dd68hSdxdlsLCqNOoqISFIkWhR+FDzGu2Yq7bkmv6mT3oriqGOIiCRNokVhsbv/+fgGM3t0soXngsFL/ZSeG+D0ezZGHUVEJGkSHX300ARtv5bEHBnn1MFXyBmFhRtUFERk9rjeLKkPmtkOYJWZPTnu8TyQsRPivdHYxae/+Rp9A8Mz3kbrvtcBWH7zrcmKJSISuet1H70MtAKlwFfGtV8gw6fOfvFYBz89eJYHbqmY0fp9Rw+yxOCmzbcnOZmISHSuN0vqKeAU8L7UxEmNd68oJlY0n531LTMuCpw4TUdpLpvyFyU3nIhIhBKdJfXjZnbMzHrMrNfMLphZb9jhwpKVZdy3Oca/HG2np39oRtsoaDpPX2VJkpOJiEQr0RPNfwL8krsXufsidy9094z+E3l7XTlDI84zB9qmvW5/XzdLOoewm1aGkExEJDqJFoWz7n4o1CQpVltZxIqSfHbUt0x73cb6l8gCCjdsSn4wEZEIJXqdwi4z+1vgH4GBK43u/s4L2jKGmbGtNsZfvXCCzr4BlhTMS3jdcwd2sQyIaeSRiMwyiR4pLCI+S+qHic+Ouh3YFlaoVNleV87IqPP0/ul1IV08coihbFhRo6IgIrNLQkcK7v7rYQeJwoblhawuW8iOvS186rbEzw9knTxDx9J55M3LDzGdiEjqJTr6aJ2ZPWdm+4PXtWb2B+FGC5+Zsb2unNcbuzjbeznh9Rad6aG/SpPgicjsk2j30TeALwJDAO5eD3wyrFCptK22HHd4qr41oeV7u9oo6Rkhe82qkJOJiKReokUh391ff0fbzOeISCNrlhawMbYo4VFIjfUvAVC0/uYwY4mIRCLRotBhZqsJpss2s18hPv3FrLC9LsZbp7tp6uq/7rLt+3cDUFE7qy7yFhEBEi8KjwB/BWwws2bgC8BvhhUq1bZtLgfgqX3Xr3OXjh5hIBcq170r7FgiIimXUFFw9xPufjdQBmxw9/e7e+NU65jZt8zs3JWT00FbiZk9G0yZ8ayZFQftZmZfM7MGM6s3s5R+465Ykk9d1WJ2JtCFlNPYQsfyfLKzE73EQ0QkcyQ6+ui/mdlid7/o7hfMrNjM/ug6q/0N8NF3tD0GPOfua4HngtcA9wJrg8fDwNcT/QWSZXttjP3NvZxo75tyucUtF7i8YmmKUomIpFai3Uf3unv3lRfufh742FQruPsLXHvPhfuBJ4LnTwAPjGv/jse9Ciw2s1iC2ZLivtr47nZOMQqps/UkRX2j5GrkkYjMUokWhWwzG5sHwswWAInPC/G2Ze5+5Vu3DVgWPK8AmsYtdyZoS5lY0QJurS6ZsgupcW985FHxxrpUxRIRSalEi8J3gefM7LNm9lngWd7+i39G3N0JRjNNh5k9bGa7zGxXe3v7jUS4xra6GEfP9nGk7cKE73cdfAuAqro7krpfEZF0keiJ5j8GvgRsDB7/1d3/ZAb7O3ulWyj4eS5obwaqxi1XGbRNlOVxd9/q7lvLyspmEGFy994cI8uY9Ghh4NgxLs43lq2sSep+RUTSRaJHCrj70+7+e8HjmRnu70ngoeD5Q8A/jWv/TDAK6TagZ1w3U8qUFc7jfauXsGNvC/EDmavlNbbRFVtIVlbCH5uISEYJ7c5rZvY94BVgvZmdCbqdvgzcY2bHgLuD1wA/Bk4ADcSn1PjcDH+fG7a9tpzGzn72N1/9642OjlLSepHBlcsjSiYiEr5EB9v/CbB9OjfacfcHJ3nrrgmWdeIXyEXuozcv5w/+cT8761vYXFk01n6u6TALLzt5a9dEmE5EJFxz9s5rk1mcn8eda0vZWd96VRfS6T3xkUelNbdEFU1EJHSJFoVdZva3ZvZg0JX0cTP7eKjJIrS9rpzm7ku8ebp7rO38wb0ArNDIIxGZxRLtPhp/57UrHMjY23FO5Z6aZeTlZLFjbwvvXlkMwFDDCXoKsthYvjridCIi4ZnTd16bTOH8XH5hfRlP7WvlP2yrITvLmN90ju5YYdTRRERClejoo0oz+4dggrtzZvZDM6sMO1yUttWW035hgNdPdjEyMsyS1n6GV5VHHUtEJFSJnlP4NvFrCcqDx46gbda6a+NSFuRms6O+heZjbzF/CBasXRd1LBGRUCVaFMrc/dvuPhw8/ob4NNqzVn5eDnfXLOMn+9s4vfdlAEo36R4KIjK7JVoUOs3sU2aWHTw+BXSGGSwdbKuN0XVxkNNvvglAdd2dEScSEQlXokXh3wCfID6zaSvwK8CvhZQpbXxwXRmF83IYOd5IV1E2RUtSOpu3iEjKJVoU/gvwkLuXuftS4kXiP4cXKz3Mz83mnk3LKD17np6KouuvICKS4RItCrXBjXUAcPcuYE5c2vuxTaVUdA3RvXzZ9RcWEclwiRaFrCv3U4b4vZZJ/MK3jFY10EDuCJwsUNeRiMx+iX6xfwV4xcz+Lnj9q8TvrzDrnTvwOqXAK0PlXBocYUFedtSRRERCk+hNdr4DfBw4Gzw+7u7/J8xg6eLCkYOMAsdy1vCzw+euu7yISCZLuAvI3Q8CB0PMkpb8xCk6l+RQWLSEnfUt3FerbiQRmb10C7HrKGjqpK+yhPs2L+dnh8/RNzAcdSQRkdCoKEzhUn8vSzqG8Juq2F5XzsDwKD89eDbqWCIioVFRmMKpfS+T7VC4roZ3rSgmVjSfHXtboo4lIhIaFYUptO1/A4Dlm28lK8vYVhvjhWPt9PQPRZxMRCQcKgpTuHjkEMNZUL3pdiA+nfbQiPPMgbaIk4mIhENFYQp2sonOsjzyFuQDUFtZxIqSfHbUqwtJRGYnFYUpLDrTzcWq0rHXZsb2uhgvH++ko28gwmQiIuFQUZhEX08HS84PYzetuKp9W205I6PO0/vVhSQis4+KwiQa618CoGjD5qvaNywvZM3SAnZqFJKIzEIqCpM4t38XAOW1t13VbhYfhfR6YxdtPZejiCYiEhoVhUn0Hz3MYA5Urd96zXvbastxh6f2tUaQTEQkPCoKk8g52ULHsvnk5OZd896apQXUxBaxU6OQRGSWUVGYxKKWHi5VlU36/ra6GG+d7qapqz+FqUREwqWiMIHz7U0U946Ss2bVpMtsry0H1IUkIrOLisIETu2JjzxavLF20mWqSvKpq1qsuZBEZFZRUZhAx4E3Aaiqu2PK5bbXxjjQ0suJ9r5UxBIRCZ2KwgQuHzvKpTyI3TT5kQLERyGZwc56dSGJyOwQSVEws0Yz22dme8xsV9BWYmbPmtmx4GdxFNkAck+10RlbSFbW1B/P8qL5vGdlibqQRGTWiPJI4RfcfYu7X7kQ4DHgOXdfCzwXvE650dFRSpovMLByWULLb6+LcexcH0faLoScTEQkfOnUfXQ/8ETw/AnggShCdLQ0UHDJyVuzOqHlP3pzjCxDRwsiMitEVRQc+Gcz221mDwdty9z9Sud8G5DYn+pJdmXkUXHNloSWLyucx+2rS9lR34K7h5hMRCR8URWF97v7u4B7gUfM7APj3/T4t+uE37Bm9rCZ7TKzXe3t7UkPdv7gHgBWbnl/wutsr4txqrOf/c29Sc8jIpJKkRQFd28Ofp4D/gG4FThrZjGA4Oe5SdZ93N23uvvWsrLJrzieqcGG4/QtMErL1yS8zkc2LScny3TzHRHJeCkvCma20MwKrzwHPgzsB54EHgoWewj4p1RnA5h3+ixd5QXXHXk03uL8PD6wroyn6lsZHVUXkohkriiOFJYBL5nZXuB14Cl3/wnwZeAeMzsG3B28TqnR0VGWtFxkqDo27XW31cZo7r7EW03nQ0gmIpIaOaneobufAOomaO8E7kp1nvFaT9SzYBDmr1037XXvqVlGXk4WO/a28u6VJSGkExEJXzoNSY1c096fA7AkwZFH4xXOz+UX1y/lqX2tjKgLSUQylIrCON2H9wFQveXOGa2/rS5G+4UBXjvZmcxYIiIpo6IwznDDSboLsyheumJG6//ihqXk52VrLiQRyVgqCuMsOH2OnoqiGa+fn5fDXRuX8fS+VoZGRpOYTEQkNVQUAsNDg5SevczwqvIb2s722hjn+4d4+bi6kEQk86goBJqO7CJvGPLXrr+h7XxwfRmF83M0F5KIZCQVhUDLvlcBKNu09TpLTm1eTjYfrlnOMwfaGBgeSUY0EZGUUVEI9B7aD8CqGY48Gm97XYwLl4d54WjHDW9LRCSVVBQCoydO0VmcQ0FR6Q1v6441pRTn56oLSUQyjopCYGFTB72Vi5OyrdzsLD56c4yfHjrLpUF1IYlI5lBRAAYv9bOkfRCvrkzaNrfXxegfHOFnhyec7FVEJC2pKACnDr5Czigs3LAxadt876ollBXOUxeSiGQUFQWgdd/rACy/+dakbTM7y7hvc4znj5zjwuWhpG1XRCRMKgrAhSMHGDFYufn2pG53W22MgeFRfnrobFK3KyISFhUFwE400Vmay4L8RUnd7rtWFFNeNJ+dezUXkohkBhUFoOBMF32Vyb8HQlaWsa2unBeOtdPdP5j07YuIJNucLwr9fd0s6RzGbloZyva31cYYGnGeOdAWyvZFRJJpzheFxvqXyAIKN2wKZfubK4pYuSRf02mLSEaY80Xh7P43AIjVvjeU7ZsZ22pj/Lyhg46+gVD2ISKSLHO+KPQfOcxQNqzcGE5RANheV86ow9P71YUkIultzheFrJNn6Fg6j9y8+aHtY/2yQtYuLdCFbCKS9uZ8UVjU3EN/1Y1PgjeVeBdSOW80dtHWcznUfYmI3Ig5XRR6u9oo6Rkhe82q0Pe1rS6GOzy1TyecRSR9zemicHLPCwAUbdgc+r5WlxVQE1ukLiQRSWtzuih0HHgTgMra96Vkf9vrytnT1E1TV39K9iciMl1zuihcOnaUgVyoWHtLSva3rTYGoGsWRCRtzemikNPYQsfyfLKzc1Kyv6qSfLZULWZnvbqQRCQ9zemisLjlApdXLE3pPrfXlXOgpZfj7X0p3a+ISCLmbFHoaDlOUd8ouWtuSul+79scwwzNnCoiaWnOFoXTe38OQHFNXUr3u7xoPu+pLmFHfQvuntJ9i4hcz5wtCh0H3wKgqja5N9ZJxPbaGA3n+jhy9kLK9y0iMpU5WxQGGxq4ON9YtrIm5fu+d3OMLHUhiUgaSruiYGYfNbMjZtZgZo+FtZ+8xja6YgvJykr9R1BaMI871pSqC0lE0k5aFQUzywb+ArgXqAEeNLOk/yk/OjpKSetFBquXJ3vTCdtWG+NUZz/7mnsiyyAi8k5pVRSAW4EGdz/h7oPA94H7k72Ts6cOsvCyk7dmTbI3nbCPbFpObrbpQjYRSSupuWorcRVA07jXZ4Ck3+ig6e/+I4VAad8b8O37kr35hCwGdhT00vvaMHt3p1ttFpF0l11ey82f/XrSt5tuReG6zOxh4GGAFStWzGgbefNyObk2h/eWLkhmtGmrLM6npedSpBlEJDNl52aHst10KwrNQNW415VB2xh3fxx4HGDr1q0zOku75dG/ZcujM42YPAXAuqhDiIiMk279Fm8Aa81slZnlAZ8Enow4k4jInJFWRwruPmxmnweeAbKBb7n7gYhjiYjMGWlVFADc/cfAj6POISIyF6Vb95GIiERIRUFERMaoKIiIyBgVBRERGaOiICIiYyyTZ+k0s3bg1AxXLwU6khgn0+nzuJo+j7fps7jabPg8Vrp72URvZHRRuBFmtsvdt0adI13o87iaPo+36bO42mz/PNR9JCIiY1QURERkzFwuCo9HHSDN6PO4mj6Pt+mzuNqs/jzm7DkFERG51lw+UhARkXeYk0XBzD5qZkfMrMHMHos6T5TMrMrMnjezg2Z2wMzS4E4T0TKzbDN7y8x2Rp0lama22Mz+3swOm9khM3tf1JmiYma/E/wb2W9m3zOz+VFnCsOcKwpmlg38BXAvUAM8aGY10aaK1DDwu+5eA9wGPDLHPw+AR4FDUYdIE38O/MTdNwB1zNHPxcwqgN8Gtrr7zcSn9v9ktKnCMeeKAnAr0ODuJ9x9EPg+cH/EmSLj7q3u/mbw/ALxf/QV0aaKjplVAvcBfx11lqiZWRHwAeCbAO4+6O7dkYaKVg6wwMxygHygJeI8oZiLRaECaBr3+gxz+EtwPDOrBm4BXos4SpT+J/DvgdGIc6SDVUA78O2gO+2vzWxh1KGi4O7NwJ8Cp4FWoMfd/znaVOGYi0VBJmBmBcAPgS+4e2/UeaJgZtuAc+6+O+osaSIHeBfwdXe/BbgIzMlzcGZWTLxHYRVQDiw0s09Fmyocc7EoNANV415XBm1zlpnlEi8I33X3H0WdJ0J3AL9kZo3EuxV/0cz+b7SRInUGOOPuV44c/554kZiL7gZOunu7uw8BPwJujzhTKOZiUXgDWGtmq8wsj/jJoicjzhQZMzPifcaH3P2rUeeJkrt/0d0r3b2a+P8XP3P3WfnXYCLcvQ1oMrP1QdNdwMEII0XpNHCbmeUH/2buYpaedE+7ezSHzd2HzezzwDPERxB8y90PRBwrSncAnwb2mdmeoO33g3tli/wW8N3gD6gTwK9HnCcS7v6amf098CbxEXtvMUuvbNYVzSIiMmYudh+JiMgkVBRERGSMioKIiIxRURARkTEqCiIiMkZFQWQagllDPxc8Lw+GKYrMGhqSKjINwfxQO4OZMkVmnTl38ZrIDfoysDq40O8YsNHdbzazXwMeABYCa4lPnpZH/MLAAeBj7t5lZquJT91eBvQD/9bdD6f6lxCZjLqPRKbnMeC4u28B/t073rsZ+DjwHuBLQH8wkdwrwGeCZR4Hfsvd3w38HvCXqQgtkigdKYgkz/PBPSkumFkPsCNo3wfUBjPR3g78XXz6HADmpT6myORUFESSZ2Dc89Fxr0eJ/1vLArqDowyRtKTuI5HpuQAUzmTF4D4VJ83sVyE+Q62Z1SUznMiNUlEQmQZ37wR+bmb7gf8xg038a+CzZrYXOMAcvhWspCcNSRURkTE6UhARkTEqCiIiMkZFQURExqgoiIjIGBUFEREZo6IgIiJjVBRERGSMioKIiIz5/wj/pwDNRiZGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'    time, [m1_A_attribute],      [m1_B], [m2_B], [D]\\n [[    0,              120,           0,      0,   0],\\n  [    1,     -1.19921e-31, 4.59414e-26,    240, 240],\\n  [    2,     -7.49388e-32, 2.87095e-26,    240, 240],\\n  [    3,     -2.99568e-32, 1.14776e-26,    240, 240],\\n  [    4,     -2.13856e-35, 9.74894e-30,    240, 240],\\n  [    5,     -2.07307e-35, 9.45045e-30,    240, 240],\\n  [    6,     -2.00759e-35, 9.15197e-30,    240, 240],\\n  [    7,     -1.94211e-35, 8.85348e-30,    240, 240],\\n  [    8,     -1.87662e-35,   8.555e-30,    240, 240],\\n  [    9,     -1.81114e-35, 8.25651e-30,    240, 240]]\\n'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import roadrunner\n",
+    "    x0 = {str(A):120}\n",
+    "    timepoints = range(0,10)\n",
+    "    result = CRN.simulate_with_roadrunner(timepoints, initial_condition_dict = x0)\n",
+    "    import pylab\n",
+    "    pylab.plot (result[:,0],result[:,1:])\n",
+    "    pylab.xlabel('time')\n",
+    "    pylab.ylabel('concentration')\n",
+    "    pylab.show()\n",
+    "except ModuleNotFoundError:\n",
+    "    warnings.warn('libroadrunner was not found, please install libroadrunner')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rr = None\n",
+    "try:\n",
+    "    import roadrunner\n",
+    "    x0 = {str(A):120}\n",
+    "    rr = CRN.simulate_with_roadrunner(timepoints=range(0,10), initial_condition_dict = x0, return_roadrunner=True)\n",
+    "except ModuleNotFoundError:\n",
+    "    warnings.warn('libroadrunner was not found, please install libroadrunner')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['[m1_A_attribute]', '[m1_B]', '[m2_B]', '[D]']\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD7CAYAAACRxdTpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAb1ElEQVR4nO3daWxd553f8e+fq8RFFDeRl4tISqIWSiJlDyM7dpyZieOJHUvjzJuBAzQxBgE0QJ3WKQIUSVC086IB8mImbVO0BpxxZjxokDRN0om3xBM7QR3vlmxxEbVREndS3ERSFCVu9+kLXtmkxeXybof38PcBCF4+9yw/XVg/Hz187rnmnENERPwlxesAIiISeyp3EREfUrmLiPiQyl1ExIdU7iIiPqRyFxHxoTXL3cwqzez3ZtZmZmfM7KnQ+N+YWa+ZnQ59fXHRPt82s3YzO29mX4jnH0BERO5ka61zN7MAEHDOfWBmucAp4EvAXwKTzrm//cT2dcBPgKNAGfAqsNc5Nx/7+CIispy0tTZwzvUD/aHH183sLFC+yi6PAT91zk0DV8ysnYWif3ulHYqKilx1dfV6couIbHqnTp0ads4VL/fcmuW+mJlVA3cB7wL3A183s68CJ4FvOueusVD87yzarYfV/2dAdXU1J0+eXE8UEZFNz8w6V3ou7F+omlkO8AvgG865CeBpYDdwhIUr+79bZ6gTZnbSzE4ODQ2tZ1cREVlDWOVuZuksFPuPnXO/BHDOXXXOzTvngsAPWZh6AegFKhftXhEaW8I594xzrtE511hcvOy/KkREJELhrJYx4FngrHPu+4vGA4s2+wugNfT4eeBxM8s0sxqgFngvdpFFRGQt4cy53w98BWgxs9Ohse8AXzazI4ADOoC/BnDOnTGznwFtwBzwpFbKiIgkVjirZd4AbJmnXl5ln+8C340il4iIREHvUBUR8SGVu4iID61rnbssr/vCKVqe+wG4oNdRRCTJFN3zAEcfOxHz46rcY6Dpv/9ndv/2HKp2EVmvjtk5ULlvTOkdffRUZfPQK3qXrYisz8E4HVdz7jGwve860zt3eB1DROQjKvcoDfW2s+2GI33Pbq+jiIh8ROUepc7TfwCgoK7B4yQiIh9TuUdp9GwTAFVHHvA4iYjIx1TuUZq52M7kVqOovNbrKCIiH1G5Rymjc4DRshxSUvRSisjGoUaKQjAYpLD/BrNVpV5HERFZQuUehYErrWRNQ2btXq+jiIgsoXKPQnfzWwAUHbzL4yQiIkup3KNwrW1hpUy1VsqIyAajco/C3KXLjOWmkL9jp9dRRESWULlHYWvXEONl27yOISJyB5V7hObn5ygcuMlcTbnXUURE7qByj1DP+VNkzkHW3n1eRxERuYPKPUI9oZUyxQcbPU4iInInlXuEJs61AlCjlTIisgGp3CMUvNTBSH4qOXlFXkcREbmDyj1CWd0jTJTnex1DRGRZKvcIzExPUTQ4jaup8DqKiMiyVO4R6Gp7l7QgZO8/4HUUEZFlqdwj0NfyDgAlBz/lcRIRkeWp3CMwea6NoEF1/f1eRxERWZbKPRKXuxguSmdrlm49ICIbk8o9Ajk915isKPA6hojIilTu6zQ1OUbhyCy2S3eCFJGNS+W+Tp0tb5LiIGffQa+jiIisSOW+Tldb3weg7PA9HicREVnZmuVuZpVm9nszazOzM2b2VGi8wMx+a2YXQ9/zQ+NmZj8ws3Yzazazu+P9h0ikG+fPMpsKO+uOeh1FRGRF4Vy5zwHfdM7VAfcCT5pZHfAt4DXnXC3wWuhngEeA2tDXCeDpmKf2UEpHL8M7MsnIzPI6iojIitYsd+dcv3Pug9Dj68BZoBx4DHgutNlzwJdCjx8D/skteAfYbmaBWAf3yraeMaYqdbMwEdnY1jXnbmbVwF3Au0CJc64/9NQAUBJ6XA50L9qtJzSW9CZGBygYmyd1V7XXUUREVhV2uZtZDvAL4BvOuYnFzznnHODWc2IzO2FmJ83s5NDQ0Hp29UxH8xsA5B047HESEZHVhVXuZpbOQrH/2Dn3y9Dw1dvTLaHvg6HxXqBy0e4VobElnHPPOOcanXONxcXFkeZPqKHWUwCU13/a4yQiIqsLZ7WMAc8CZ51z31/01PPAE6HHTwC/WjT+1dCqmXuB8UXTN0nt5sULTKdDxV5fLQASER9KC2Ob+4GvAC1mdjo09h3ge8DPzOxrQCfwl6HnXga+CLQDU8BfxTKwl9I6+hgu2Upqajgvm4iId9ZsKefcG4Ct8PSDy2zvgCejzLUhbe+dYLi+cu0NRUQ8pneohml0oJO8ySDptbu8jiIisiaVe5g6mv4AQP6BBo+TiIisTeUeppEzHwJQ2aAP6BCRjU/lHqbp9otMZRolVXVeRxERWZPKPUwZHQOMlGWTkqKXTEQ2PjVVGILBIAV9k8xUlXodRUQkLCr3MAx1nyf7liOjdo/XUUREwqJyD0Nn08I9ZYrq7vI4iYhIeFTuYbjW1gTATq2UEZEkoXIPw2z7JSayjaKy3V5HEREJi8o9DFu6BrlWts3rGCIiYVO5r2F+fo6CgSnmasq8jiIiEjaV+xr6LjWxdQa21u71OoqISNhU7mvoaXoLgKI63cNdRJKHyn0NY2ebAag+8oDHSUREwqdyX8P8pQ5G81LJKwx4HUVEJGwq9zVkdQ8zUZ7ndQwRkXVRua9iduYWhVdvEayp8DqKiMi6qNxX0XXufTLmIWvvPq+jiIisi8p9Ff3N7wCw41Cjx0lERNZH5b6KiXNnCALV9Z/xOoqIyLqo3FfhLncyUphGdm6B11FERNZF5b6K7J5RJsvzvY4hIrJuKvcVTN+cpGhoBrer0usoIiLrpnJfwZWWN0l1kLvvoNdRRETWTeW+goGW9wAoPXzU4yQiIuuncl/BjQvnmEuB6oP3eR1FRGTdVO4rsCtdjBRlkLE1y+soIiLrpnJfQW7PGDcqC72OISISEZX7MibHRygancN2V3kdRUQkIir3ZXQ0/wGAvP2HPU4iIhIZlfsyBs+cAqCs/l6Pk4iIREblvoyb588xkwaV+3TDMBFJTmuWu5n9yMwGzax10djfmFmvmZ0OfX1x0XPfNrN2MztvZl+IV/B4SunoZbhkC2npGV5HERGJSDhX7v8IPLzM+H9xzh0Jfb0MYGZ1wOPAwdA+/9PMUmMVNlHyese5WVnsdQwRkYitWe7OudeB0TCP9xjwU+fctHPuCtAOJNVbPMeGe8mfCJK2p8brKCIiEYtmzv3rZtYcmra5fevEcqB70TY9obE7mNkJMztpZieHhoaiiBFbHU0LK2W2H6j3OImISOQiLfengd3AEaAf+Lv1HsA594xzrtE511hcvHGmQIZbF1bKVNTrtgMikrwiKnfn3FXn3LxzLgj8kI+nXnqBxffIrQiNJY1bFy9yMwPKdjd4HUVEJGIRlbuZBRb9+BfA7ZU0zwOPm1mmmdUAtcB70UVMrPSOfkYC2aSkaJWoiCSvtLU2MLOfAH8CFJlZD/CfgD8xsyOAAzqAvwZwzp0xs58BbcAc8KRzbj4uyeMkv+86g436ZaqIJLc1y9059+Vlhp9dZfvvAt+NJpRXhnrbyZ1yjO3Z7XUUEZGoaO5hkc7TCytl8rVSRkSSnMp9kdG20wBUHXnA2yAiIlFSuS8yc7Gdya1GUXmt11FERKKicl8ks+sqo2U5WikjIklPLRYSDAYp6L/BbHVg7Y1FRDY4lXvIwJVWsqYhc4+mZEQk+ancQ7qa3gCg6OBdHicREYmeyj1k7GwzANVaKSMiPqByD5lrv8JYbgr5O3Z6HUVEJGoq95Ct3UOMl+d5HUNEJCZU7sDc7AyFAzeZqy7zOoqISEyo3IGeC6fInIOsvfu8jiIiEhMqd6C3+W0Aig82epxERCQ2VO7AxNmF29HXaKWMiPiEyh0IXulkJD+VnLwir6OIiMSEyh3I6h5hojx/7Q1FRJLEpi/3mZtTFA1O42oqvI4iIhIzm77cO9veJi0I2fsPeB1FRCRmkrrc3+8Y5SvPvsvk9FzEx+hvWfj87tJDR2MVS0TEc0ld7gB/uDjMq21XI95/8kIbQYOqw/fFMJWIiLeSutz/aGc+gbwtvNjcF/lBLncxXJTO1qxtsQsmIuKxpC73lBTj0cMB/t+FIcanZiM6Rk73NSYrCmKcTETEW0ld7gDHG8qYnXe8cmZg3ftOTY5RODKL7aqKQzIREe8kfbnXV+SxsyCLFyKYmulofoMUIHf/wdgHExHxUNKXu5lxrD7AW5dGGJmcXte+g2dOAhDQShkR8ZmkL3dYmJqZDzp+3bq+qZkb588ymwo761TuIuIvvij3/aW57C7O5oWm9U3NpFzpYXhHJhmZWXFKJiLiDV+Uu5lxvKGM9zpGuTpxK+z9tvWMM1Wpm4WJiP/4otwBjtWX4Ry81Nwf1vYTowMUjM+TuqcmzslERBLPN+W+Z0cOBwLbwl4109H8BgB5+w7FM5aIiCd8U+4AxxsCfNg1Rvfo1JrbDrWeAqC8/tPxjiUiknC+Kvdjhxc+4PqllrWnZm5eOM90OlTsvTvesUREEm7NcjezH5nZoJm1LhorMLPfmtnF0Pf80LiZ2Q/MrN3Mms0soc25szCLhsrtYd1rJq2jj+HSLFJT0xKQTEQkscK5cv9H4OFPjH0LeM05Vwu8FvoZ4BGgNvR1Ang6NjHDd7w+QGvvBJeHJlfdbnvfdW7t3JGgVCIiibVmuTvnXgdGPzH8GPBc6PFzwJcWjf+TW/AOsN3MAjHKGpZH6xdO9+Iqq2ZG+q+QNxkkXStlRMSnIp1zL3HO3W7PAaAk9Lgc6F60XU9oLGECeVs5Wl2w6tRMR9PCSpn8Aw2JiiUiklBR/0LVOecAt979zOyEmZ00s5NDQ0PRxljiWEOAC1cnOT9wfdnnR9s+BKCy4f6YnldEZKOItNyv3p5uCX0fDI33ApWLtqsIjd3BOfeMc67ROddYXFwcYYzlPXIoQIqx4tX79MWL3NhilFTVxfS8IiIbRaTl/jzwROjxE8CvFo1/NbRq5l5gfNH0TcIU52by6d2FvNDUx8I/LJbK6BhgNJBNSoqvVoKKiHwknKWQPwHeBvaZWY+ZfQ34HvCQmV0EPh/6GeBl4DLQDvwQ+NdxSR2G4/VldIxM0do7sWQ8GAxS0H+DmapSj5KJiMTfmou8nXNfXuGpB5fZ1gFPRhsqFh4+VMp/+OdWXmzu43BF3kfjg93nyL7lyKjd42E6EZH48u28xPasDB6oLeLF5v4lUzNdpxdWyhTV3eVVNBGRuPNtucPCh3j0jt3kg66xj8autTUBsFMrZUTEx3xd7g/VlZCRlrLkQzxm2y8znpNCUdluD5OJiMSXr8s9d0s6f7qvmJda+pkPLkzNbOkeZCyQ63EyEZH48nW5w8KHeAxdn+a9K6PMz89R2D/FXE2Z17FEROLK97dEfPDADramp/JCcx/ls5fZMgtba/d6HUtEJK58f+WelZHG5+tK+E3rAF1NbwFQdFD3cBcRf/N9uQMcqw8wemOGrg8+AKC64QGPE4mIxNemKPc/3ltMbmYa85c6GM1LJa8woXchFhFJuE1R7lvSU3noYAlFV68xXp639g4iIkluU5Q7wBcPFlE+OstYacnaG4uIJDnfr5a5rXK6neA8XMnRlIyI+N+muXIfPPMeAG/PlnFzZt7jNCIi8bVpyv36+TaCwMW0Pfzu3OCa24uIJLNNU+7ucicjhWnk5hWu+vmqIiJ+sGnKPad7hMmKAh49XMrvzg0yOT3ndSQRkbjZFOV+c2qCwuFZ3K5KjjeUMT0X5NW2q17HEhGJm01R7p0tb5HqIHdvHXfvzCeQt2XJbYBFRPxmU5T7QOv7AJQePkpKinGsPsDrF4cYn5r1OJmISHxsinK/cf4scylQffA+YOE2wLPzjlfODHicTEQkPjZFuduVbkaKM8jYmgVAfUUeOwuyeEGrZkTEpzZFuW/rGeNGZdFHP5sZxxsCvHVphOHJaQ+TiYjEh+/LfXJ8mMJrc9iunUvGj9WXMR90/LpVUzMi4j++L/eO5jcAyNt/eMn4/tJc9uzI4UWtmhERH/J9uQ+2ngSgrP7eJeNmC6tm3usYZWD8lhfRRETixvflPnXhHDNpULmv8Y7njtWX4Ry81NLvQTIRkfjxfbmnXeljuGQLaekZdzy3Z0cOdYFtuteMiPiO78t9W984NyuLV3z+WEOAD7vG6B6dSmAqEZH48nW5XxvqJn8iSNqemhW3OV5fBmhqRkT8xdfl3nl6YaXM9gP1K25TWZBFQ+V23WtGRHzF1+U+fOYDACob7l91u+P1Ac70TXB5aDIRsURE4s7X5X7r4gVuZkBg18pX7rCwasYMXmzW1IyI+ENU5W5mHWbWYmanzexkaKzAzH5rZhdD3/NjE3X90jsHGAlkk5Ky+h+zNG8Ln6oq0NSMiPhGLK7c/9Q5d8Q5d3sh+beA15xztcBroZ8TLhgMUtB7nemqkrC2P94Q4OLgJOcHrsc5mYhI/MVjWuYx4LnQ4+eAL8XhHGsa7msn56YjY8/usLZ/+FCAFENX7yLiC9GWuwP+xcxOmdmJ0FiJc+725PUAEN6lc4zdXimTX3ckrO2LczO5b3cRLzT34ZyLYzIRkfiLttw/45y7G3gEeNLMPrv4SbfQkss2pZmdMLOTZnZyaGgoyhh3utZ2GoCqI58Je5/jDQE6R6Zo7Z2IeR4RkUSKqtydc72h74PA/wWOAlfNLAAQ+j64wr7POOcanXONxcUrv4M0UjPtl5jcahSV7Ql7ny8cLCUtxfQhHiKS9CIudzPLNrPc24+BPwNageeBJ0KbPQH8KtqQkcjsuspoWc6aK2UW256VwWf3FvNScz/BoKZmRCR5RXPlXgK8YWZNwHvAS8653wDfAx4ys4vA50M/J1QwGKSw7waz1YF173usPkDv2E0+7L4Wh2QiIomRFumOzrnLQMMy4yPAg9GEilb/5Wa2zsCW2r3r3vehuhIy0lJ4oamfP6oqiEM6EZH48+U7VLub3gSgMMyVMovlbknnc/t28FJLP/OamhGRJOXLch871wJA9ZEHItr/WEOAoevTvHtlJJaxREQSxpflPtd+hbHcFPJ37Fx742V8bv8OsjJSda8ZEUlaviz3rV2DjJfnRbx/VkYaDx4o4dct/czOB2OYTEQkMXxX7nOzMxRdvcVcTVlUxzleH+Da1CxvXdLUjIgkH9+Ve/f5k2TMQVbtvqiO88f7isndkqZ7zYhIUvJdufe1vANA8cHGNbZcXWZaKn9WV8orZwaYnpuPRTQRkYTxXblPnG0FoCbClTKLHW8IcP3WHK9fGI76WCIiieS7cg9e7mQkP42cvKKoj3X/niLys9I1NSMiScd35Z7dPcxExfaYHCs9NYWHDwV49exVbs5oakZEkoevyn3m5hSFQzO46oqYHfN4Q4CpmXl+d27Zm1uKiGxIvir3zra3SQtC9v4DMTvmPTWFFOdmampGRJKKr8q9v+U9AEoPHY3ZMVNTjEcPB/j9+UGu35qN2XFFROLJV+V+/fwZ5g2qDt8X0+Meqw8wPRfk1bNXY3pcEZF48VW52+VuRorS2Zq1LabHvXtnPmV5W3ixSfeaEZHk4Ktyz+kZZbIi9vdgT0kxjjWU8frFIcamZmJ+fBGRWPNNuU9NjlE4MoftqorL8Y/VB5idd7xyZiAuxxcRiSXflHtH8xukALn7D8bl+IfL86gqzNJtgEUkKfim3K+2vg9AoP6euBzfzDhWH+DN9mGGJ6fjcg4RkVjxTblPnT/HbCpUHYhPuQMcbygj6ODXrZqaEZGNzTflnnKlh+EdmaRnbInbOfaV5FK7I0dvaBKRDc835b6td5ypyuhvFraahamZMt7vGGVg/FZczyUiEg1flPvE6AAF4/Ok7qmJ+7mONQRwDl5q0S9WRWTj8kW5Xzn9OgB5+w/H/Vy7i3OoC2zT1IyIbGi+KPfhMx8AUFH/6YSc73hDGae7x+genUrI+URE1ssX5X7z4gWm06G89q6EnO9YfQBAa95FZMPyRbmndfQxXJpFampaQs5XWZDFkcrtvNisqRkR2Zh8Ue7b+65za+eOhJ7zeEMZZ/omuDQ0mdDzioiEI+nLfbjvEnmTQdL37EroeR89HMAM3SlSRDakpC/3rqY3Aciva0joeUvztvCp6gJeaO7DOZfQc4uIrCXpy3247UMAKutj+wEd4TheH6B9cJLzV68n/NwiIqtJ+nKfaW/nxhajpKou4ed+5HCAFE3NiMgGFLdyN7OHzey8mbWb2bfidZ6MjgFGA9mkpCT+/1NFOZncv6dIUzMisuHEpRHNLBX4H8AjQB3wZTOL+aV1MBikoP8GM9WlsT502I7VB+gcmaKld9yzDCIinxSvy92jQLtz7rJzbgb4KfBYrE9ytbON7FuOjD17Yn3osH3hYCnpqaY3NInIhhKvd/2UA92Lfu4BYn6j9e7/8x/JBYom34d/eDTWhw/LduCFnAkm3p2j6VTS/wpDRBIstayeQ197OubHTcxbOpdhZieAEwA7d+6M6BgZmelcqU3jnqKtsYy2bhX5WfSN3/Q0g4gkp9T01LgcN17l3gtULvq5IjT2EefcM8AzAI2NjRH9NvLIU/+bI09FGjF2coC9XocQEVkkXvMI7wO1ZlZjZhnA48DzcTqXiIh8Qlyu3J1zc2b2deAVIBX4kXPuTDzOJSIid4rbnLtz7mXg5XgdX0REVqblHSIiPqRyFxHxIZW7iIgPqdxFRHxI5S4i4kO2Ee5maGZDQGeEuxcBwzGMk+z0eiyl1+Njei2W8sPrUeWcK17uiQ1R7tEws5POuUavc2wUej2W0uvxMb0WS/n99dC0jIiID6ncRUR8yA/l/ozXATYYvR5L6fX4mF6LpXz9eiT9nLuIiNzJD1fuIiLyCUld7on6EO5kYGaVZvZ7M2szszNmtgHudO8tM0s1sw/N7EWvs3jNzLab2c/N7JyZnTWzT3udyStm9u9Cf0dazewnZrbF60zxkLTlnqgP4U4ic8A3nXN1wL3Ak5v89QB4CjjrdYgN4r8Bv3HO7Qca2KSvi5mVA/8WaHTOHWLhluSPe5sqPpK23EnQh3AnC+dcv3Pug9Dj6yz85S33NpV3zKwCeBT4e6+zeM3M8oDPAs8COOdmnHNjnobyVhqw1czSgCygz+M8cZHM5b7ch3Bv2jJbzMyqgbuAdz2O4qX/Cvx7IOhxjo2gBhgC/iE0TfX3ZpbtdSgvOOd6gb8FuoB+YNw59y/epoqPZC53WYaZ5QC/AL7hnJvwOo8XzOwYMOicO+V1lg0iDbgbeNo5dxdwA9iUv6Mys3wW/oVfA5QB2Wb2r7xNFR/JXO5rfgj3ZmNm6SwU+4+dc7/0Oo+H7gf+3Mw6WJiu+5yZ/S9vI3mqB+hxzt3+l9zPWSj7zejzwBXn3JBzbhb4JXCfx5niIpnLXR/CvYiZGQtzqmedc9/3Oo+XnHPfds5VOOeqWfjv4nfOOV9enYXDOTcAdJvZvtDQg0Cbh5G81AXca2ZZob8zD+LTXy7H7TNU400fwn2H+4GvAC1mdjo09p3QZ9mK/Bvgx6ELocvAX3mcxxPOuXfN7OfAByysMPsQn75TVe9QFRHxoWSelhERkRWo3EVEfEjlLiLiQyp3EREfUrmLiPiQyl1ExIdU7iIiPqRyFxHxof8Pc4jjUh5HtTsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if rr is not None:\n",
+    "    rr.reset()\n",
+    "    res2 = rr.simulate( start=0, end=9, points=10)\n",
+    "    pylab.plot (res2[:,0],res2[:,1:])\n",
+    "    pylab.legend(rr.timeCourseSelections[1:])\n",
+    "    pylab.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The reset function is needed to simulate the ODE from the inital condition not from the end of the last simulation time point. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR refactors the roadrunner interface.

This new interface allows simulating CRNs with roadrunner (libroadrunner). Two main operation mode (determined by return_roadrunner flag): getting back numerical results or getting back the roadrunner model object for further analysis.

* refactor function name: simulate_with_roadrunner to keep it consistent with bioscraper
* unit test adjusted to detect both cases: libroadrunner is installed or not and
* an example Jupyter notebook is added