### PR TITLE
refactor Promoter and RBS initialization in DNAassembly

### DIFF
--- a/Tests/test_dna_part_promoter.py
+++ b/Tests/test_dna_part_promoter.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2020, Build-A-Cell. All rights reserved.
+#  See LICENSE file in the project root directory for details.
+
+import pytest
+from biocrnpyler import Promoter, Species
+
+
+def test_promoter_from_promoter():
+    test_name = 'test_promoter'
+    test_length = 10
+    prom = Promoter(name=test_name, length=test_length)
+
+    assert prom.assembly is None
+    assert prom.transcript is None
+    assert prom.protein is None
+
+    test_assembly = 'test_assembly'
+    test_transcript = 'test_transcript'
+    test_protein = 'test_protein'
+    prom2= Promoter.from_promoter(name=prom,assembly=test_assembly, transcript=test_transcript, protein=test_protein)
+
+    assert prom2.assembly == test_assembly
+    assert prom2.transcript == test_transcript
+    assert prom2.protein == test_protein
+    # check that original values are kept
+    assert prom2.name == test_name
+    assert prom2.length == test_length
+
+    with pytest.raises(TypeError, match='Promoter can be initialized from string or another promoter!'):
+        Promoter.from_promoter(name=Species(name=test_name), assembly=test_assembly, transcript=test_transcript, protein=test_protein)

--- a/Tests/test_dna_part_rbs.py
+++ b/Tests/test_dna_part_rbs.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2020, Build-A-Cell. All rights reserved.
+#  See LICENSE file in the project root directory for details.
+
+import pytest
+from biocrnpyler import RBS, Species
+
+
+def test_promoter_from_rbs():
+    test_name = 'test_rbs'
+    test_length = 10
+    rbs = RBS(name=test_name, length=test_length)
+
+    assert rbs.assembly is None
+    assert rbs.transcript is None
+    assert rbs.protein is None
+
+    test_assembly = 'test_assembly'
+    test_transcript = 'test_transcript'
+    test_protein = 'test_protein'
+    rbs2= RBS.from_rbs(name=rbs,assembly=test_assembly, transcript=test_transcript, protein=test_protein)
+
+    assert rbs2.assembly == test_assembly
+    assert rbs2.transcript == test_transcript
+    assert rbs2.protein == test_protein
+    # check that original values are kept
+    assert rbs2.name == test_name
+    assert rbs2.length == test_length
+
+    with pytest.raises(TypeError, match='RBS can be initialized from string or another RBS!'):
+        rbs.from_rbs(name=Species(name=test_name), assembly=test_assembly, transcript=test_transcript, protein=test_protein)

--- a/biocrnpyler/dna_assembly.py
+++ b/biocrnpyler/dna_assembly.py
@@ -1,7 +1,6 @@
 #  Copyright (c) 2019, Build-A-Cell. All rights reserved.
 #  See LICENSE file in the project root directory for details.
 
-import copy
 from typing import List, Union
 
 from .component import Component
@@ -132,19 +131,10 @@ class DNAassembly(DNA):
         if transcript is not None:
             self.update_transcript(transcript)
 
-        if isinstance(promoter, str):
-            self.promoter = Promoter(assembly=self, name=promoter,
-                                     transcript=self.transcript,
-                                     protein=protein)
-        elif isinstance(promoter, Promoter):
-            self.promoter = copy.deepcopy(promoter)
-            self.promoter.assembly = self
-            self.promoter.transcript = self.transcript
-            self.promoter.protein = protein
-        elif promoter is not None:
-            raise ValueError("Improper promoter type received by DNAassembly. "
-                             "Expected string or promoter object. "
-                             f"Received {repr(promoter)}.")
+        if promoter is not None:
+            self.promoter = Promoter.from_promoter(name=promoter, assembly=self,
+                                                   transcript=self.transcript,
+                                                   protein=protein)
         else:
             self.promoter = None
 
@@ -167,16 +157,9 @@ class DNAassembly(DNA):
         if transcript is not None:
             self.update_transcript(transcript)
 
-        if isinstance(rbs, str):
-            self.rbs = RBS(assembly=self, name=rbs, protein=self.protein,
-                           transcript=self.transcript)
-        elif isinstance(rbs, RBS):
-            self.rbs = copy.deepcopy(rbs)
-            self.rbs.assembly = self
-            self.rbs.transcript = self.transcript
-            self.rbs.protein = self.protein
-        elif rbs is not None:
-            raise ValueError(f"Improper rbs type received by DNAassemby. Expected string or RBS object. Received {repr(rbs)}.")
+        if rbs is not None:
+            self.rbs = RBS.from_rbs(name=rbs, assembly=self, protein=self.protein,
+                                    transcript=self.transcript)
         else:
             self.rbs = None
 

--- a/biocrnpyler/dna_part_promoter.py
+++ b/biocrnpyler/dna_part_promoter.py
@@ -105,6 +105,29 @@ class Promoter(DNA_part):
         else:
             return None
 
+    @classmethod
+    def from_promoter(cls, name, assembly, transcript, protein):
+        """Helper function to initialize a promoter instance from another promoter or str.
+
+        :param name: either string or an other promoter instance
+        :param assembly:
+        :param transcript:
+        :param protein:
+        :return: Promoter instance
+        """
+        if isinstance(name, Promoter):
+            promoter_instance = copy.deepcopy(name)
+            promoter_instance.assembly = assembly
+            promoter_instance.transcript = transcript
+            promoter_instance.protein = protein
+        elif isinstance(name, str):
+            promoter_instance = cls(name=name, assembly=assembly,
+                                    transcript=transcript, protein=protein)
+        else:
+            raise TypeError(f'Promoter can be initialized from string or another promoter! We got {type(name)}')
+        return promoter_instance
+
+
 class RegulatedPromoter(Promoter):
     """
     A Promoter class with simple regulation.

--- a/biocrnpyler/dna_part_rbs.py
+++ b/biocrnpyler/dna_part_rbs.py
@@ -76,3 +76,25 @@ class RBS(DNA_part):
                 out_component.transcript = dna
             #my_rna.get_species()
         return out_component
+
+    @classmethod
+    def from_rbs(cls, name, assembly, transcript, protein):
+        """Helper function to initialize a rbs instance from another rbs or str.
+
+        :param name: either string or an other rbs instance
+        :param assembly:
+        :param transcript:
+        :param protein:
+        :return: RBS instance
+        """
+        if isinstance(name, RBS):
+            rbs_instance = copy.deepcopy(name)
+            rbs_instance.assembly = assembly
+            rbs_instance.transcript = transcript
+            rbs_instance.protein = protein
+        elif isinstance(name, str):
+            rbs_instance = cls(name=name, assembly=assembly,
+                               transcript=transcript, protein=protein)
+        else:
+            raise TypeError(f'RBS can be initialized from string or another RBS! We got {type(name)}')
+        return  rbs_instance


### PR DESCRIPTION
Promoter and RBS initialization logic was exposed to the DNAassembly. This has been moved inside the respective classes, and from_promoter() and from_rbs() class methods are introduced to handle the different cases.
- [X] **unit test**: New Unittests are included. 
- [X] **examples**: No example was modified

closes #150
