### PR TITLE
pre-generate sbml ids for species and reactions

### DIFF
--- a/Tests/test_sbml.py
+++ b/Tests/test_sbml.py
@@ -229,8 +229,8 @@ def test_generate_sbml_model():
     assert len(model.getListOfReactions()) == len(crn.reactions)
 
     document2, model2 = crn.generate_sbml_model(check_validity=False)
-    assert(model==model2) #the same model is made if you dont check validity
-    assert(document==document2) #the same model is made if you dont check validity
+    assert len(model2.getListOfSpecies()) == len(crn.species) #the same model is made if you dont check validity
+    assert len(model2.getListOfReactions()) == len(crn.reactions) #the same model is made if you dont check validity
     
     # reversible needs to be off!
     # assert not model.getListOfReactions()[0].isSetReversible()

--- a/Tests/test_sbml.py
+++ b/Tests/test_sbml.py
@@ -228,6 +228,10 @@ def test_generate_sbml_model():
     # all reactions from the CRN are accounted for
     assert len(model.getListOfReactions()) == len(crn.reactions)
 
+    document2, model2 = crn.generate_sbml_model(check_validity=False)
+    assert(model==model2) #the same model is made if you dont check validity
+    assert(document==document2) #the same model is made if you dont check validity
+    
     # reversible needs to be off!
     # assert not model.getListOfReactions()[0].isSetReversible()
 
@@ -354,7 +358,6 @@ def test_sbml_basics():
     S2 = Species("S2")
     compartment = add_compartment(model, S1.compartment)
     check(compartment, 'add compartment')
-    print(trans.getValidIdForName(str(S1)))
     sbml_species = add_species(
         model, compartment, str(S1.name),trans.getValidIdForName(str(S1)), initial_concentration=10)
     sbml_species2 = add_species(

--- a/Tests/test_sbml.py
+++ b/Tests/test_sbml.py
@@ -338,6 +338,14 @@ def test_sbml_basics():
     # generate an sbml model
     document, model = create_sbml_model()
 
+
+    elementlist = model.getSBMLDocument().getListOfAllElements()
+
+    all_ids = getAllIds(elementlist)
+
+    trans = SetIdFromNames(all_ids)
+
+
     # If the document/model creation failed the following two lines
     # will catch it:
     check(document, 'create SBMLDocument object')
@@ -346,10 +354,11 @@ def test_sbml_basics():
     S2 = Species("S2")
     compartment = add_compartment(model, S1.compartment)
     check(compartment, 'add compartment')
+    print(trans.getValidIdForName(str(S1)))
     sbml_species = add_species(
-        model, compartment, S1, initial_concentration=10)
+        model, compartment, str(S1.name),trans.getValidIdForName(str(S1)), initial_concentration=10)
     sbml_species2 = add_species(
-        model, compartment, S2, initial_concentration=10)
+        model, compartment, str(S2.name),trans.getValidIdForName(str(S2)), initial_concentration=10)
     check(sbml_species.getId(), 'get ID for SBML species')
     check(sbml_species.getInitialConcentration(),
           'get concentration for SBML species')

--- a/biocrnpyler/chemical_reaction_network.py
+++ b/biocrnpyler/chemical_reaction_network.py
@@ -271,7 +271,7 @@ class ChemicalReactionNetwork(object):
 
         return ChemicalReactionNetwork(new_species_list, new_reaction_list)
 
-    def generate_sbml_model(self, stochastic_model=False, show_warnings = False, **keywords):
+    def generate_sbml_model(self, stochastic_model=False, show_warnings = False, check_validity = True,**keywords):
         """Creates an new SBML model and populates with the species and
         reactions in the ChemicalReactionNetwork object
 
@@ -280,8 +280,8 @@ class ChemicalReactionNetwork(object):
         :param keywords: extra keywords pass onto create_sbml_model() and add_all_reactions()
         :return: tuple: (document,model) SBML objects
         """
-        ChemicalReactionNetwork.check_crn_validity(self._reactions, self._species, show_warnings=show_warnings)
-
+        if(check_validity):
+            ChemicalReactionNetwork.check_crn_validity(self._reactions, self._species, show_warnings=show_warnings)
         document, model = create_sbml_model(**keywords)
         all_compartments = []
         for species in self._species:
@@ -290,16 +290,14 @@ class ChemicalReactionNetwork(object):
         add_all_compartments(model = model, compartments = all_compartments, **keywords)
         
         add_all_species(model=model, species=self._species, initial_condition_dictionary = self.initial_concentration_dict)
-
         add_all_reactions(model=model, reactions=self._reactions, stochastic_model=stochastic_model, **keywords)
-
         
 
         if document.getNumErrors():
             warn('SBML model generated has errors. Use document.getErrorLog() to print all errors.')
         return document, model
 
-    def write_sbml_file(self, file_name=None, stochastic_model = False, **keywords) -> bool:
+    def write_sbml_file(self, file_name=None, stochastic_model = False, check_validity = True, **keywords) -> bool:
         """"Writes CRN object to a SBML file
 
         :param file_name: name of the file where the SBML model gets written
@@ -307,8 +305,7 @@ class ChemicalReactionNetwork(object):
         :param keywords: keywords that passed into generate_sbml_model()
         :return: bool, show whether the writing process was successful
         """
-
-        document, _ = self.generate_sbml_model(stochastic_model = stochastic_model, **keywords)
+        document, _ = self.generate_sbml_model(stochastic_model = stochastic_model, check_validity = check_validity,**keywords)
         sbml_string = libsbml.writeSBMLToString(document)
         with open(file_name, 'w') as f:
             f.write(sbml_string)
@@ -332,7 +329,7 @@ class ChemicalReactionNetwork(object):
 
     def simulate_with_bioscrape_via_sbml(self, timepoints, filename = None,
                 initial_condition_dict = None, return_dataframe = True,
-                stochastic = False, safe = False, return_model = False, **kwargs):
+                stochastic = False, safe = False, return_model = False, check_validity=True, **kwargs):
 
         """Simulate CRN model with bioscrape via writing a SBML file temporarily.
         [Bioscrape on GitHub](https://github.com/biocircuits/bioscrape).
@@ -346,7 +343,7 @@ class ChemicalReactionNetwork(object):
             from bioscrape.types import Model
 
             if filename is None:
-                self.write_sbml_file(file_name ="temp_sbml_file.xml", stochastic_model = stochastic, for_bioscrape = True)
+                self.write_sbml_file(file_name ="temp_sbml_file.xml", stochastic_model = stochastic, for_bioscrape = True,check_validity=check_validity)
                 file_name = "temp_sbml_file.xml"
             elif isinstance(filename, str):
                 file_name = filename

--- a/biocrnpyler/chemical_reaction_network.py
+++ b/biocrnpyler/chemical_reaction_network.py
@@ -282,6 +282,7 @@ class ChemicalReactionNetwork(object):
         """
         if(check_validity):
             ChemicalReactionNetwork.check_crn_validity(self._reactions, self._species, show_warnings=show_warnings)
+        
         document, model = create_sbml_model(**keywords)
         all_compartments = []
         for species in self._species:
@@ -369,7 +370,7 @@ class ChemicalReactionNetwork(object):
         else:
             return result
 
-    def simulate_with_roadrunner(self, timepoints: List[float], initial_condition_dict: Dict[str,float]=None, return_roadrunner=False):
+    def simulate_with_roadrunner(self, timepoints: List[float], initial_condition_dict: Dict[str,float]=None, return_roadrunner=False, check_validity=True):
         """To simulate using roadrunner.
         Arguments:
         timepoints: The array of time points to run the simulation for.
@@ -385,7 +386,7 @@ class ChemicalReactionNetwork(object):
         try:
             import roadrunner
             import io
-            document, _ = self.generate_sbml_model(stochastic_model=False)
+            document, _ = self.generate_sbml_model(stochastic_model=False, check_validity=check_validity)
             sbml_string = libsbml.writeSBMLToString(document)
             # write the sbml_string into a temporary file in memory instead of a file
             string_out = io.StringIO()


### PR DESCRIPTION
pre-generate all unique ids for species and reactions before iterating through all species and reactions to improve sbml model generation speed