### PR TITLE
Allow disallow specific integrase reaction types

### DIFF
--- a/Tests/test_integrase_enumerator.py
+++ b/Tests/test_integrase_enumerator.py
@@ -68,7 +68,9 @@ def test_integrase_rule():
         bad_rule.generate_products(delete[0],delete[2]) #attP->attB reaction is not possible with a bad rule
     
     aL = IntegraseSite("attL","attL",integrase="Bxb1")
+    aL.direction= "forward"
     aR = IntegraseSite("attR","attR",integrase="Bxb1")
+    aR.direction = "forward"
     productsites = bxb1_rule.generate_products(delete[0],delete[2])
 
     testaL = copy.copy(aL)

--- a/biocrnpyler/integrase_enumerator.py
+++ b/biocrnpyler/integrase_enumerator.py
@@ -256,8 +256,22 @@ class IntegraseRule:
         assert(isinstance(site2,IntegraseSite))
         assert site1.integrase==site2.integrase
         assert site1.integrase==self.integrase_species
-        if(tuple([site1.site_type,site2.site_type]) in self.reactions):
-            return True
+        if(tuple(site1.site_type,site2.site_type) in self.reactions):
+            #this means these site types can react
+            if(site1.parent==site2.parent):
+                #this means the sites are on the same piece of DNA
+                if(site1.direction==site2.direction):
+                    #this is a deletion reaction
+                    if(self.allow_deletion):
+                        return True
+                else:
+                    #this is an inversion reaction
+                    if(self.allow_inversion):
+                        return True
+            else:
+                #these sites are on a different piece of DNA. That means it's integration
+                if(self.allow_integration):
+                    return True
         return False
     def generate_products(self,site1,site2):
         """generates DNA_part objects corresponding to the products of recombination"""

--- a/biocrnpyler/integrase_enumerator.py
+++ b/biocrnpyler/integrase_enumerator.py
@@ -256,22 +256,8 @@ class IntegraseRule:
         assert(isinstance(site2,IntegraseSite))
         assert site1.integrase==site2.integrase
         assert site1.integrase==self.integrase_species
-        if(tuple(site1.site_type,site2.site_type) in self.reactions):
-            #this means these site types can react
-            if(site1.parent==site2.parent):
-                #this means the sites are on the same piece of DNA
-                if(site1.direction==site2.direction):
-                    #this is a deletion reaction
-                    if(self.allow_deletion):
-                        return True
-                else:
-                    #this is an inversion reaction
-                    if(self.allow_inversion):
-                        return True
-            else:
-                #these sites are on a different piece of DNA. That means it's integration
-                if(self.allow_integration):
-                    return True
+        if(tuple([site1.site_type,site2.site_type]) in self.reactions):
+            return True
         return False
     def generate_products(self,site1,site2):
         """generates DNA_part objects corresponding to the products of recombination"""
@@ -389,8 +375,8 @@ class IntegraseRule:
                     #case 2: deletion
                     #if the sites point in the same direction, then we are doing a deletion reaction
                     #direction doesn't matter so we don't need to flip anything
-                    cutdna_list_parts = list(dna[:cutpos1])+[[prod1,dna[cutpos1].direction]]+list(dna[cutpos2+1:]) #delete
-                    newdna_list_parts = [[prod2,dna[cutpos2].direction]]+list(dna[1+cutpos1:cutpos2])
+                    cutdna_list_parts = list(dna[:cutpos1])+[[prod1,site1.direction]]+list(dna[cutpos2+1:]) #delete
+                    newdna_list_parts = [[prod2,site2.direction]]+list(dna[1+cutpos1:cutpos2])
 
                     integ_funcs += [Polymer_transformation(cutdna_list_parts,circular = circularity),\
                                             Polymer_transformation(newdna_list_parts,circular=True)]
@@ -406,9 +392,9 @@ class IntegraseRule:
                     #the inverted segment is reversed
                     
                     invertdna_list = list(dna[:cutpos1])+\
-                                    [[prod1,dna[cutpos1].direction]]+\
+                                    [[prod1,site1.direction]]+\
                                     inv_segment+ \
-                                    [[prod2,dna[cutpos2].direction]]+\
+                                    [[prod2,site2.direction]]+\
                                     list(dna[cutpos2+1:])
 
                     integ_funcs += [Polymer_transformation(invertdna_list,circular=circularity)]
@@ -417,8 +403,6 @@ class IntegraseRule:
                 #otherwise these sites are on different pieces of DNA, so they are going to combine
                 dna1 = site1.parent
                 dna2 = site2.parent
-                circ1 = dna1.circular
-                circ2 = dna2.circular
                 if(dna1 == dna2):
                     #this will happen if we trying to do an intermolecular reaction between two copies of the same thing
                     dna2 = copy.copy(dna1)
@@ -439,7 +423,8 @@ class IntegraseRule:
                 dna1_halves = site_halves[0]
                 dna2_halves = site_halves[1]
 
-                
+                circ1 = dna1.circular
+                circ2 = dna2.circular
                 
                 if(site1.direction=="reverse" and site2.direction=="reverse"):
                     prod1,prod2 = self.generate_products(site2,site1)

--- a/biocrnpyler/integrase_enumerator.py
+++ b/biocrnpyler/integrase_enumerator.py
@@ -375,8 +375,8 @@ class IntegraseRule:
                     #case 2: deletion
                     #if the sites point in the same direction, then we are doing a deletion reaction
                     #direction doesn't matter so we don't need to flip anything
-                    cutdna_list_parts = list(dna[:cutpos1])+[[prod1,site1.direction]]+list(dna[cutpos2+1:]) #delete
-                    newdna_list_parts = [[prod2,site2.direction]]+list(dna[1+cutpos1:cutpos2])
+                    cutdna_list_parts = list(dna[:cutpos1])+[[prod1,dna[cutpos1].direction]]+list(dna[cutpos2+1:]) #delete
+                    newdna_list_parts = [[prod2,dna[cutpos2].direction]]+list(dna[1+cutpos1:cutpos2])
 
                     integ_funcs += [Polymer_transformation(cutdna_list_parts,circular = circularity),\
                                             Polymer_transformation(newdna_list_parts,circular=True)]
@@ -392,9 +392,9 @@ class IntegraseRule:
                     #the inverted segment is reversed
                     
                     invertdna_list = list(dna[:cutpos1])+\
-                                    [[prod1,site1.direction]]+\
+                                    [[prod1,dna[cutpos1].direction]]+\
                                     inv_segment+ \
-                                    [[prod2,site2.direction]]+\
+                                    [[prod2,dna[cutpos2].direction]]+\
                                     list(dna[cutpos2+1:])
 
                     integ_funcs += [Polymer_transformation(invertdna_list,circular=circularity)]
@@ -403,6 +403,8 @@ class IntegraseRule:
                 #otherwise these sites are on different pieces of DNA, so they are going to combine
                 dna1 = site1.parent
                 dna2 = site2.parent
+                circ1 = dna1.circular
+                circ2 = dna2.circular
                 if(dna1 == dna2):
                     #this will happen if we trying to do an intermolecular reaction between two copies of the same thing
                     dna2 = copy.copy(dna1)
@@ -423,8 +425,7 @@ class IntegraseRule:
                 dna1_halves = site_halves[0]
                 dna2_halves = site_halves[1]
 
-                circ1 = dna1.circular
-                circ2 = dna2.circular
+                
                 
                 if(site1.direction=="reverse" and site2.direction=="reverse"):
                     prod1,prod2 = self.generate_products(site2,site1)


### PR DESCRIPTION
maybe sometimes you want to make an integrase reaction that can only react within the same piece of DNA and not with other copies of that DNA or you want an integrase that can only delete and can't integrate.

Well, now you can specify that by writing something like this:
`bxb1_nodel_mechanism = IntegraseRule("Bxb1",allow_deletion=False)`

Other options include
`allow_deletion`
`allow_integration`
`allow_inversion`

and if you want to prevent reactions with a copy of the same DNA you have to create a part (any part) that has an attribute called `"no_inter"`. That allows you to have many dnas in a single reaction where some of them can react with copies of themselves and others can't. (That part was already done in #234 but I thought I'd mention it here anyway)