### PR TITLE
Operator and UserDefined dna_part_misc improvement

### DIFF
--- a/Tests/test_dna_part.py
+++ b/Tests/test_dna_part.py
@@ -1,5 +1,5 @@
 import pytest
-from biocrnpyler import DNA_part
+from biocrnpyler import DNA_part, Operator, UserDefined
 
 def test_instantiation():
 
@@ -33,3 +33,15 @@ def test_equality_without_ordered_polymer():
     partfor = DNA_part("part",direction="forward")
     x = part1.set_dir("forward")
     assert partfor == x
+
+def test_misc_parts():
+    p1 = Operator("op1",binder=["b1"])
+
+    assert(p1.name=="op1")
+    assert(len(p1.binder)==1)
+    assert(p1.binder[0].name=="b1")
+
+    u1 = UserDefined("op2",dpl_type="Origin")
+
+    assert(u1.name=="op2")
+    assert(u1.dpl_type=="Origin")

--- a/biocrnpyler/dna_part_misc.py
+++ b/biocrnpyler/dna_part_misc.py
@@ -214,10 +214,11 @@ class IntegraseSite(DNABindingSite):
         return reactions
 
 class UserDefined(DNA_part):
-    def __init__(self,name, **keywords):
+    def __init__(self,name,dpl_type=None, **keywords):
         """a user defined part is a part that doesn't do anything, 
         just exists as a label basically"""
         DNA_part.__init__(self,name, **keywords)
+        self.dpl_type = dpl_type
         self.name = name
     def update_species(self):
         return []
@@ -228,6 +229,19 @@ class Origin(DNA_part):
     def __init__(self,name, **keywords):
         """an origin does nothing except look right when plotted"""
         DNA_part.__init__(self,name, **keywords)
+        self.name = name
+    def update_species(self):
+        return []
+    def update_reactions(self):
+        return []
+class Operator(DNA_part):
+    def __init__(self,name,binder=None, **keywords):
+        """an operator does nothing except look right when plotted"""
+        DNA_part.__init__(self,name, **keywords)
+        self.binder = []
+        if(binder is not None):
+            for bind in binder:
+                self.binder += [Component.set_species(bind)]
         self.name = name
     def update_species(self):
         return []

--- a/biocrnpyler/plotting.py
+++ b/biocrnpyler/plotting.py
@@ -13,7 +13,7 @@ from warnings import warn
 
 from .components_basic import Protein, DNA, RNA
 from .dna_part_cds import CDS
-from .dna_part_misc import IntegraseSite, Origin
+from .dna_part_misc import IntegraseSite, Origin, Operator, UserDefined
 from .dna_part_promoter import Promoter
 from .dna_part_rbs import RBS
 from .dna_part_terminator import Terminator
@@ -774,6 +774,13 @@ class CRNPlotter:
                 dpl_type = "CDS"
             elif(isinstance(part,Protein)):
                 dpl_type = "CDS"
+            elif(isinstance(part,Operator)):
+                dpl_type="Operator"
+            elif(isinstance(part,Origin)):
+                dpl_type = "Origin"
+            elif(isinstance(part,UserDefined)):
+                if(part.dpl_type is not None):
+                    dpl_type = part.dpl_type
             elif(isinstance(part,Terminator)):
                 dpl_type = "Terminator"
             elif(isinstance(part,IntegraseSite)):


### PR DESCRIPTION
minor addition to `dna_part_misc` which allows you to specify any dnaplotlib glyph in a `UserDefined` part (by setting `dpl_type`) and also adding the ability to create `Operator` parts which don't do anything CRN-wise except for look good when plotted.