### PR TITLE
write the duration of the 10 slowest unit tests to the console

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # pytest.ini
 [pytest]
 minversion = 5.4
-addopts = --nbval-lax --cov=biocrnpyler
+addopts = --nbval-lax --cov=biocrnpyler --durations=10
 testpaths =
     Tests
     examples


### PR DESCRIPTION
Just a small PR to get a better understanding of the pytest running time
With the durations flag in the config file, pytest reports the run time of the unit tests to the console, like this:

<img width="1298" alt="Screenshot 2021-06-15 at 08 45 14" src="https://user-images.githubusercontent.com/17138838/122013361-02398c80-cdb6-11eb-8cf1-873e2bb3b679.png">
