### PR TITLE
added ability to search for DNA_part type color and plot output to svg

### DIFF
--- a/Tests/test_plotting.py
+++ b/Tests/test_plotting.py
@@ -2,6 +2,7 @@
 #  Copyright (c) 2020, Build-A-Cell. All rights reserved.
 #  See LICENSE file in the project root directory for details.
 
+from biocrnpyler.dna_construct import RNA_construct
 import pytest
 #from unittest import TestCase
 from biocrnpyler import CRNPlotter, DNA_construct, Promoter,IntegraseSite,\
@@ -77,6 +78,15 @@ def test_CRNPlotter():
     revpart = test_plotter.part_dpl_dict[RegulatedPromoter("p1",regulators=["r1","r2"])].get_directed("reverse",bound=[boundspec]) #return reverse promoter with things bound
     assert(revpart.get_dpl()[0]["type"]=="Operator") #reverse promoter has operators on the left
     
+
+    test_plotter.colordict = {"Promoter":"purple"}
+    prom_dpl = test_plotter.make_dpl_from_part(Promoter("pconst")) #make a promoter part
+    assert(prom_dpl.color == "purple") #found the proper color
+    prom_dpl2 = test_plotter.make_dpl_from_part(Promoter("funkbeast")) #make a different promoter part
+    assert(prom_dpl2.color=="purple")
+
+    rnadpl = test_plotter.make_dpl_from_species(Species("testrna",material_type="rna"))
+    assert(rnadpl.dpl_type == "NCRNA")
     #something is bound to the operator closest to the reversed promoter
     assert(revpart.parts_list[1].bound is not None)
 
@@ -85,7 +95,13 @@ def test_CRNPlotter():
     test_plotter.make_dpl_from_species(test_construct4.get_species())
     assert(test_construct4.get_species() in test_plotter.species_dpl_dict) #construct is in the dictionary
     
-    
+    rna_construct = RNA_construct([RBS("ooga"),CDS("booga")])
+    condpl1 = test_plotter.make_dpls_from_construct(rna_construct)
+    assert(condpl1.material_type == "rna") #material type is set correctly
+
+    rna_construct2 = RNA_construct([RBS("ooga"),CDS("booga")])
+    condpl2 = test_plotter.make_dpls_from_construct(rna_construct2)
+    assert(condpl2==condpl1) #this construct is already in the dictionary! Just return it
 
     
 

--- a/Tests/test_utils.py
+++ b/Tests/test_utils.py
@@ -1,9 +1,8 @@
 #  Copyright (c) 2020, Build-A-Cell. All rights reserved.
 #  See LICENSE file in the project root directory for details.
 
-from biocrnpyler import Species
-from biocrnpyler.utils import process_initial_concentration_dict
-
+from biocrnpyler import Species, Promoter, IntegraseSite, CDS
+from biocrnpyler.utils import member_dictionary_search, process_initial_concentration_dict
 
 def test_process_initial_concentration_dict():
     A = Species('A')
@@ -13,3 +12,37 @@ def test_process_initial_concentration_dict():
     processed = process_initial_concentration_dict(initial_concentration)
     for (key_old, key_new) in zip(initial_concentration.keys(), processed.keys()):
         assert str(key_old) == key_new
+def test_dictionary_search():
+    colordict = {"p1":"blue","Promoter":"red","Bxb1":"orange",\
+                    ("Bxb1","attP"):"mauve","attP":"green",\
+                    "protein":"purple",("phosphorylated",):"yellow"}
+
+
+    prom = Promoter("p1")
+    prom2 = Promoter("p2")
+    c1 = CDS("ooga")
+    prot = Species("myprot",material_type="protein")
+    rna1 = Species("myrna",material_type="rna")
+    rna1.add_attribute("phosphorylated")
+    prot2 = Species("myprot2",material_type="protein")
+    prot2.add_attribute("phosphorylated")
+    int1 = Species("Bxb1","protein")
+    int2 = IntegraseSite("attP","attP","Int1")
+    int3 = IntegraseSite("attP","attP","Bxb1")
+    int4 = IntegraseSite("attP2","attP","Bxb1")
+    int5 = IntegraseSite("attP3e","attP")
+    print(int4.name)
+    print(repr(int4))
+    print((int4.integrase,int4.site_type))
+    assert(member_dictionary_search(prom,colordict)=="blue") #DNA_part name
+    assert(member_dictionary_search(prom2,colordict)=="red") #DNA_part type
+    assert(member_dictionary_search(c1,colordict)==None) #this one is not found
+    assert(member_dictionary_search(prot,colordict)=="purple") #material type
+    assert(member_dictionary_search(rna1,colordict)=="yellow") #attribute is colored
+    assert(member_dictionary_search(prot2,colordict)=="purple") #attribute is colored
+    colordict[("protein",("phosphorylated",))]="darkblue"
+    assert(member_dictionary_search(prot2,colordict)=="darkblue") #(material_type,attribute) is colored differntly
+    assert(member_dictionary_search(int1,colordict)=="orange") #integrase protein is colored
+    assert(member_dictionary_search(int5,colordict)=="green") #site type in the dictionary
+    assert(member_dictionary_search(int3,colordict)=="green") #name of attP is more important than tuple of integrase, attP type
+    assert(member_dictionary_search(int4,colordict)=="mauve") #now integrase and type are supreme, since name doesn't match

--- a/biocrnpyler/utils.py
+++ b/biocrnpyler/utils.py
@@ -97,6 +97,10 @@ def member_dictionary_search(member,dictionary):
         return dictionary[(member.integrase,member.site_type)]
     elif(hasattr(member,"site_type") and member.site_type in dictionary):
         return dictionary[member.site_type]
+    elif(hasattr(member,"assembly")):
+        typename = type(member).__name__
+        if(typename in dictionary):
+            return dictionary[typename]
     elif(hasattr(member,"material_type") and hasattr(member,"attributes") and \
                     (member.material_type, tuple(member.attributes)) in dictionary):
         return dictionary[(member.material_type, tuple(member.attributes))]

--- a/biocrnpyler/utils.py
+++ b/biocrnpyler/utils.py
@@ -93,8 +93,8 @@ def member_dictionary_search(member,dictionary):
         return dictionary[repr(member)]
     elif(hasattr(member,"name") and member.name in dictionary):
         return dictionary[member.name]
-    elif(hasattr(member,"integrase") and hasattr(member,"site_type") and (member.integrase,member.site_type) in dictionary):
-        return dictionary[(member.integrase,member.site_type)]
+    elif(hasattr(member,"integrase") and hasattr(member,"site_type") and (str(member.integrase.name),member.site_type) in dictionary):
+        return dictionary[(str(member.integrase.name),member.site_type)]
     elif(hasattr(member,"site_type") and member.site_type in dictionary):
         return dictionary[member.site_type]
     elif(hasattr(member,"assembly")):


### PR DESCRIPTION
This minor patch adds two things:
1) the ability to color dnaplotlib parts from a color dictionary just like how we do with the network diagram
2) a keyword that lets you export as svg the dnaplotlib images generated for the species in your network

Also I fixed a bug where if you use `render_mixture` with a provided CRN and mixture, it will have an error because global component enumerators are not being reset before component enumeration is run again.