### PR TITLE
fix bug in intermolecular reaction generation

### DIFF
--- a/biocrnpyler/dna_construct.py
+++ b/biocrnpyler/dna_construct.py
@@ -553,7 +553,7 @@ class Construct(Component,OrderedPolymer):
     def __eq__(self,construct2):
         """equality means comparing the parts list in a way that is not too deep"""
         #TODO: make this be a python object comparison
-        if(self.__repr__()==construct2.__repr__()):
+        if((self.__repr__()==construct2.__repr__()) and (self.name == construct2.name)):
             return True
         else:
             return False

--- a/biocrnpyler/dna_part_misc.py
+++ b/biocrnpyler/dna_part_misc.py
@@ -189,13 +189,13 @@ class IntegraseSite(DNABindingSite):
             if(not intermolecular):
                 #this is an intramolecular reaction so we don't care about the other site's DNAs
                 integrated_dnas = []
-                site_is_bound = site.integrase in complex_parent[site.position]
-                site_isnt_bound = not isinstance(complex_parent[site.position],ComplexSpecies)
+                site_is_bound = site.integrase in complex_parent[site.position] #site is bound by integrase
+                site_isnt_bound = not isinstance(complex_parent[site.position],ComplexSpecies) #site isnt bound by anything
                 if(( (self.integrase_binding and site_is_bound) or (not self.integrase_binding and site_isnt_bound)) 
                                                                     and complex_parent in self.linked_sites[site_tpl][1]):
-                    #make sure that both this site and the other site are bound
+                    #make sure that both this site and the other site are bound, or not depending on the value of "integrase_binding"
                     for integrase_function in self.linked_sites[site_tpl][0]:
-                        integr = integrase_function.create_polymer([complex_parent],bound=self.integrase_binding)
+                        integr = integrase_function.create_polymer([complex_parent])
                         integrated_dnas += [integr]
                     reactions += int_mech.update_reactions([complex_parent],integrated_dnas,component=self,part_id = self.integrase.name)
                     populate = False
@@ -208,7 +208,7 @@ class IntegraseSite(DNABindingSite):
                     for integrase_function in self.linked_sites[site_tpl][0]:
                         #for every result that we could get, generate it
                         #the next line generates the OrderedPolymerSpecies which results from recombination
-                        integrated_dnas += [integrase_function.create_polymer([complex_parent,other_dna],bound = self.integrase_binding)]
+                        integrated_dnas += [integrase_function.create_polymer([complex_parent,other_dna])]
                     
                     reactions += int_mech.update_reactions([complex_parent,other_dna],integrated_dnas,component=self,part_id = self.integrase.name)
             #next part updates the linked site


### PR DESCRIPTION
This is fixing a weird bug i found when you have an integrase site that can also bind something that is not integrase (for example, a repressor).

Integrase sites turn into different sites (attB + attP -> attL + attR), but they need to remember that they were bound to things before and after. Thus:

1) When you do intermolecular reactions (another copy of the same piece of DNA reacts) you need to make sure there is a new polymer made which has a distinct parent, or else the polymer transformation doesn't know that there should be two inputs
2) integrase sites which turn into other integrase sites need a special way to know that their parents need to change specifically when it is an intermolecular reaction
3) dna constructs need to take their name into account when comparing to see if two constructs are equal (because i want to have two identical constructs that are not equal, in the case of doing this intermolecular reaction)