### PR TITLE
correctly compare parts at correct position during omnihash

### DIFF
--- a/Tests/Unit/test_integrase_enumerator.py
+++ b/Tests/Unit/test_integrase_enumerator.py
@@ -219,18 +219,14 @@ def test_integrase_rule():
     #
 
 def test_integrase_enumerator():
-    prom = Promoter("p1")
-    utr = RBS("utr")
     cds = CDS("GFP")
     cds2 = CDS("RFP")
-    term = Terminator("t16")
     ap = IntegraseSite("attP","attP",integrase="Bxb1")
     ab = IntegraseSite("attB","attB",integrase="Bxb1")
     al = IntegraseSite("attL","attL",integrase="Bxb1")
     ar = IntegraseSite("attR","attR",integrase="Bxb1")
 
-    aflp = IntegraseSite("FLP","FLP")
-    delete = DNA_construct([ab,cds,ap])
+
     flip = DNA_construct([ab,cds,[ap,"reverse"]])
     plasp = DNA_construct([cds,ap],circular=True)
     plasb = DNA_construct([cds,ab],circular=True)
@@ -290,6 +286,14 @@ def test_integrase_enumerator():
 
     y = bxb1_enumerator.enumerate_components([plasp,plasb],previously_enumerated=[plaspb])
     assert (y == []) #nothing new is made since the proper construct has been "previously enumerated"
+
+    plaspb = DNA_construct([ar,cds,al,cds,ar,cds,ar,cds],circular=True)
+    for i in range(1,len(plaspb)):
+        #test all circular permutations of this repetitive plasmid. They should all  yield the same hash!
+        plasperm = plaspb.get_circularly_permuted(i)
+        h1 = DNA_construct.omnihash(plaspb)
+        h2 = DNA_construct.omnihash(plasperm)
+        assert(h1[0]==h2[0])
 
 
 

--- a/biocrnpyler/dna_construct.py
+++ b/biocrnpyler/dna_construct.py
@@ -455,7 +455,7 @@ class Construct(Component,OrderedPolymer):
                 test_partlist = [(parthash,part)]
                 testpos = part.position
 
-                while test_partlist[-1][0] == best_partlist[-1][0]:
+                while test_partlist[-1][0] == best_partlist[len(test_partlist)-1][0]:
                     if(testpos-part.position>= len(construct)):
                         #this means we tested every part and they would come in at the same alphabetical position
                         break
@@ -468,7 +468,8 @@ class Construct(Component,OrderedPolymer):
                         next_part = circular_next(best_partlist[-1][1],construct)
                         next_parthash = Construct.get_partstring(next_part)
                         best_partlist += [(next_parthash,next_part)]
-                if(test_partlist[-1][0] > best_partlist[-1][0]):
+                
+                if(test_partlist[-1][0] > best_partlist[len(test_partlist)-1][0]):
                     best_partlist = test_partlist
         while(len(best_partlist)<len(construct)):
             nextpart = circular_next(best_partlist[-1][1],construct)

--- a/biocrnpyler/plotting.py
+++ b/biocrnpyler/plotting.py
@@ -822,6 +822,7 @@ class CRNPlotter:
             self.species_dpl_dict[species] = out_dpl
             return out_dpl
     def make_dpl_from_part(self,part,set_color=None,save_in_dict=True,set_color2=None):
+        """create a DNAplotlib dictionary from a part"""
         removed_part = part.get_removed()
         if(len(self.colordict)>0 and set_color is None):
             search_color = member_dictionary_search(removed_part,self.colordict)


### PR DESCRIPTION
I discovered a bug where sometimes a particularly repetitive plasmid would not properly have a unique rotation, direction invariant hash generated. The cause was that when similar part sequences are compared, the hash function saves which ones it already compared to, and I forgot to reset it to go back to the beginning if you need to compare the same thing again. So it was comparing parts at incorrect positions.

I believe I have now fixed the problem, and added a test to make sure the specific problem does not appear again.