### PR TITLE
Using py 3.7, 3.8, and 3.9 instead of 3.6, 3.7, and 3.8

### DIFF
--- a/.github/workflows/install_and_code_cov.yml
+++ b/.github/workflows/install_and_code_cov.yml
@@ -7,7 +7,7 @@ jobs:
         max-parallel: 4
         matrix:
           os: [windows-latest, ubuntu-latest, macos-latest]
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.7, 3.8, 3.9]
       steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This change is necessary because 3.6 is no longer supported PyO3 (pywinpty) which is one of our dependencies.