### PR TITLE
updates for Python 3.12 compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Install with all optional dependencies::
 
     $ pip install biocrnpyler[all]
 
+(Note that on some operating systems you made need to use "\[all\]" to avoid shell errors.)
+
 Further details about the installation process can be found in the [BioCRNPyler wiki](https://github.com/BuildACell/BioCRNPyler/wiki#installation).
 
 # Bugs

--- a/Tests/Combinatorial/test_jupyter_notebooks.py
+++ b/Tests/Combinatorial/test_jupyter_notebooks.py
@@ -2,7 +2,7 @@ import pytest
 nb_not_installed = False
 try:
     import nbformat
-    from nbconvert.preprocessors import ExecutePreprocessor
+    from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 except ModuleNotFoundError:
     nb_not_installed = True
 from os import listdir, getcwd, pardir

--- a/Tests/Unit/test_simulation_packages_import.py
+++ b/Tests/Unit/test_simulation_packages_import.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2020, Build-A-Cell. All rights reserved.
 #  See LICENSE file in the project root directory for details.
 
+import warnings
 import pytest
 
 
@@ -11,7 +12,7 @@ def test_bioscrape_import_simulate():
 
         X = Species("X")
         CRN = ChemicalReactionNetwork(species=[X],reactions=[])
-        with pytest.warns(None) as record:
+        with pytest.warns() as record:
             sim_result = CRN.simulate_with_bioscrape(timepoints=np.linspace(0, 10, 100), initial_condition_dict = {str(X):1})
 
 
@@ -33,7 +34,7 @@ def test_bioscrape_import_simulate_via_sbml():
 
         X = Species("X")
         CRN = ChemicalReactionNetwork(species=[X],reactions=[])
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             sim_result, bioscrape_model = CRN.simulate_with_bioscrape_via_sbml(timepoints=np.linspace(0, 10, 100), initial_condition_dict={str(X):1}, return_model=True)
 
 

--- a/biocrnpyler/plotting.py
+++ b/biocrnpyler/plotting.py
@@ -49,8 +49,9 @@ try:
     import networkx as nx
     from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes,
                               HoverTool, MultiLine, NodesAndLinkedEdges,
-                              PanTool, Plot, Range1d, Square, TapTool,
+                              PanTool, Plot, Range1d, TapTool,
                               WheelZoomTool)
+    from bokeh.models.markers import Square
     from bokeh.plotting import from_networkx
     from bokeh.palettes import Spectral4
     from bokeh.io import export_svgs, output_notebook
@@ -922,7 +923,7 @@ def render_mixture(mixture,crn,color_dictionary=None,output = None,compiled_comp
 def render_network_bokeh(CRN,layout="force", layoutfunc = None, plot_reactions = True, plot_species = True, plot_edges = True, plot_arrows = True,
                         iterations=2000,rseed=30,posscale=1,export=False,species_glyph_size = 12, reaction_glyph_size = 8, export_name = None, **keywords):
     DG, DGspec, DGrxn = generate_networkx_graph(CRN,**keywords) #this creates the networkx objects
-    plot = Plot(plot_width=500, plot_height=500, x_range=Range1d(-500, 500), y_range=Range1d(-500, 500)) #this generates a 
+    plot = Plot(width=500, height=500, x_range=Range1d(-500, 500), y_range=Range1d(-500, 500)) #this generates a
     show_im = False
     images = None
     if("imagedict" in keywords and keywords["imagedict"] is not None):

--- a/biocrnpyler/sbmlutil.py
+++ b/biocrnpyler/sbmlutil.py
@@ -37,7 +37,7 @@ def create_sbml_model(compartment_id="default", time_units='second', extent_unit
     document = libsbml.SBMLDocument(3, 2)
     model = document.createModel()
     if model_id is None:
-        model_id = 'biocrnpyler_'+str(randint(1, 1e6))
+        model_id = 'biocrnpyler_'+str(randint(1, int(1e6)))
     model.setId(model_id)
     model.setName(model_id)
     # Define units for area (not used, but keeps COPASI from complaining)

--- a/examples/Specialized Tutorials/1. CombinatorialPromoter Details.ipynb
+++ b/examples/Specialized Tutorials/1. CombinatorialPromoter Details.ipynb
@@ -640,7 +640,7 @@
     "#below is CRN plotting code. set plotCRN to False to disable\n",
     "if(plotCRN):\n",
     "    DG, DGspec, DGrxn = generate_networkx_graph(CRN_extract_1)\n",
-    "    plot = Plot(plot_width=500, plot_height=500, x_range=Range1d(-500, 500), y_range=Range1d(-500, 500))\n",
+    "    plot = Plot(width=500, height=500, x_range=Range1d(-500, 500), y_range=Range1d(-500, 500))\n",
     "    graphPlot(DG,DGspec,DGrxn,plot)\n",
     "    bokeh.io.show(plot)\n",
     "\n",

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
           ],
     extras_require = { 
         "all": [
-            "numpy",
+            "numpy<2.0",
             "matplotlib",
             "networkx",
             "bokeh>=1.4.0",
-            "fa2",
+            "fa2_modified",
             "jupyter",
             "pytest",
             "pytest-cov",


### PR DESCRIPTION
This PR includes a number of small updates to allow bioCRNpyler to install properly on Python 3.12 (also tested on Python 3.8).  The changes are all small and reflect updates in `fa2`, `bokeh`, and `nbconvert`.

Note that numpy 2.0 also causes problems.  Since this just came out 3 days ago, for now I have pinned numpy < 2.0 in `setup.py`

A bit more info:
* fa2: the original fa2 is no longer maintained and fails after Python 3.8.  A modified version is available in [fa2_modified](https://github.com/AminAlam/fa2_modified)
* Fixed an error in a `randint` call were `1e6` was being interpreted as a float (so I explicitly converted it to an `int`).
* The current version of bokeh uses `width` to set the width instead of `plot_width`.
* There were some small issues in unit test infrastructure in the way that warnings were handled and some changes in how exceptions are declared that I fixed.

Unit tests on my local machine all pass if `bioscrape` is installed (if not, there is a bug in `examples/Specialized\ Tutorials/1.\ CombinatorialPromoter\ Details.ipynb` that causes a failure).

It would be useful if this PR could be checked, merged, and pushed to PyPI in the next few days, so that bioCRNpyler is working when I talk about it at SEED (on 25 Jun 2024...).