### PR TITLE
Default mechanisms in Components + Update PURE mixture, mechanisms, and parameters

### DIFF
--- a/Tests/Unit/test_chemicalReactionNetwork.py
+++ b/Tests/Unit/test_chemicalReactionNetwork.py
@@ -228,7 +228,7 @@ class TestChemicalReactionNetwork(TestCase):
     def test_get_all_species_containing(self):
         # test that the species arument must be Species object
         with self.assertRaisesRegex(
-            ValueError, 'species argument must be an instance of Species!'
+            ValueError, 'species argument must be an instance of Species'
         ):
             self.crn.get_all_species_containing(species=self.species_list)
 

--- a/Tests/Unit/test_component_basic.py
+++ b/Tests/Unit/test_component_basic.py
@@ -11,7 +11,11 @@ def test_enzyme():
     products = 'P1'
     enzyme = 'E1'
 
-    e = Enzyme(enzyme=enzyme, substrates=substrates, products=products)
+    e = Enzyme(
+        enzyme=enzyme, substrates=substrates, products=products,
+    )
+    e.default_mechanism=None  # override failsafe
+
     assert any([s.name == 'S1' for s in e.substrates])
     assert any([p.name == 'P1' for p in e.products])
     assert enzyme == e.enzyme.name

--- a/Tests/Unit/test_component_membrane.py
+++ b/Tests/Unit/test_component_membrane.py
@@ -21,6 +21,7 @@ def test_DiffusibleMolecule():
 
     assert dm.get_species().name == 'DP'
 
+    dm.default_mechanism = None  # override failsafe
     with pytest.raises(
         KeyError,
         match='Unable to find mechanism of type diffusion in Component',
@@ -46,6 +47,7 @@ def test_IntegralMembraneProtein():
 
     assert imp.get_species().name == 'MP1'
 
+    imp.default_mechanism = None  # override failsafe
     with pytest.raises(
         KeyError,
         match='Unable to find mechanism of type membrane_insertion in Component',
@@ -70,6 +72,7 @@ def test_MembraneChannel():
 
     assert mc.get_species().name == 'IMP1'
 
+    mc.default_mechanism = None  # override failsafe
     with pytest.raises(
         KeyError,
         match='Unable to find mechanism of type transport in Component',
@@ -94,6 +97,7 @@ def test_MembranePump():
 
     assert mp.get_species().name == 'MPump1'
 
+    mp.default_mechanism = None  # override failsafe
     with pytest.raises(
         KeyError,
         match='Unable to find mechanism of type transport in Component',
@@ -125,6 +129,7 @@ def test_MembraneSensor():
 
     assert ms.get_species().name == 'MSensor1'
 
+    ms.default_mechanism = None  # override failsafe
     with pytest.raises(
         KeyError,
         match='Unable to find mechanism of type membrane_sensor in Component',

--- a/Tests/Unit/test_mixture.py
+++ b/Tests/Unit/test_mixture.py
@@ -2,6 +2,7 @@
 #  See LICENSE file in the project root directory for details.
 
 from unittest import TestCase
+from warnings import catch_warnings, filterwarnings, simplefilter, warn
 
 from biocrnpyler import (
     DNA,
@@ -271,6 +272,31 @@ class TestMixture(TestCase):
                 ]
             )
         )
+
+    def test_compile_crn_keeps_warning_filters(self):
+        # compile_crn used to call resetwarnings(), which discarded any
+        # warning filters set up by the caller
+        a = Species(name='a')
+        b = Species(name='b')
+
+        component = Component('comp')
+        component.update_species = lambda: [a, b]
+        component.update_reactions = lambda: [
+            Reaction.from_massaction(inputs=[a], outputs=[b], k_forward=0.1)
+        ]
+        mixture = Mixture(components=[component])
+
+        with catch_warnings(record=True) as log:
+            simplefilter('always')
+            filterwarnings('ignore', message='suppress me')
+
+            mixture.compile_crn()
+
+            warn('suppress me', UserWarning)
+            warn('report me', UserWarning)
+
+        # The filter installed before compiling should still be in effect
+        self.assertEqual([str(entry.message) for entry in log], ['report me'])
 
     def test_compile_crn_directives(self):
         a = Species(name='a')

--- a/Tests/Unit/test_parameter.py
+++ b/Tests/Unit/test_parameter.py
@@ -6,6 +6,8 @@ from unittest import TestCase
 from unittest.mock import mock_open, patch
 from warnings import warn
 
+import pytest
+
 from biocrnpyler import (
     Mechanism,
     ModelParameter,
@@ -558,6 +560,21 @@ def test_findpath(tmp_path):
             os.environ['BCP_PATH'] = prev_bcp_path
 
 
+def basic_pure(*args, **kwargs):
+    """Build a legacy BasicPURE mixture, checking that it warns.
+
+    A filter set up ahead of time (whether by a pytest.mark.filterwarnings
+    decorator or by catch_warnings) does not survive here, because
+    `Mixture.compile_crn` calls `resetwarnings`.  Catching the warning at
+    the point it is raised avoids that.
+
+    """
+    import biocrnpyler as bcp
+
+    with pytest.warns(DeprecationWarning, match='BasicPURE is deprecated'):
+        return bcp.BasicPURE(*args, **kwargs)
+
+
 def test_parameter_ordering():
     import biocrnpyler as bcp
 
@@ -570,7 +587,7 @@ def test_parameter_ordering():
         'GFP', promoter=ptet, rbs='RBS', protein='GFP')
 
     # Default case: make sure we can compile with no additional paramters
-    default_mixture = bcp.BasicPURE(
+    default_mixture = basic_pure(
         'default', components=[dna_GFP, TetR_inactive])
     default_crn = default_mixture.compile_crn()
 
@@ -607,7 +624,7 @@ def test_parameter_ordering():
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP',
         parameters=baseline_parameters)
-    baseline_mixture = bcp.BasicPURE(
+    baseline_mixture = basic_pure(
         'baseline', components=[dna_GFP, TetR_inactive])
     baseline_crn = baseline_mixture.compile_crn()
     assert baseline_crn.reactions[
@@ -625,7 +642,7 @@ def test_parameter_ordering():
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP',
         parameters=mechtype_parameters)
-    mechtype_mixture = bcp.BasicPURE(
+    mechtype_mixture = basic_pure(
         'mechtype', components=[dna_GFP, TetR_inactive])
     mechtype_crn = mechtype_mixture.compile_crn()
     assert mechtype_crn.reactions[
@@ -643,7 +660,7 @@ def test_parameter_ordering():
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP',
         parameters=partid_parameters)
-    partid_mixture = bcp.BasicPURE(
+    partid_mixture = basic_pure(
         'partid', components=[dna_GFP, TetR_inactive])
     partid_crn = partid_mixture.compile_crn()
     assert partid_crn.reactions[
@@ -661,7 +678,7 @@ def test_parameter_ordering():
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP',
         parameters=mechname_parameters)
-    mechname_mixture = bcp.BasicPURE(
+    mechname_mixture = basic_pure(
         'mechname', components=[dna_GFP, TetR_inactive])
     mechname_crn = mechname_mixture.compile_crn()
     assert mechname_crn.reactions[
@@ -677,7 +694,7 @@ def test_parameter_ordering():
     TetR_inactive=bcp.ChemicalComplex([TetR.species, aTc])
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP')
-    mixture_mixture = bcp.BasicPURE(
+    mixture_mixture = basic_pure(
         'mixture', components=[dna_GFP, TetR_inactive],
         parameters=mixture_parameters)
     mixture_crn = mixture_mixture.compile_crn()
@@ -696,7 +713,7 @@ def test_parameter_ordering():
     dna_GFP = bcp.DNAassembly(
         'GFP', promoter=ptet, rbs='RBS', protein='GFP',
         parameters=component_parameters)
-    mixture_mixture = bcp.BasicPURE(
+    mixture_mixture = basic_pure(
         'mixture', components=[dna_GFP, TetR_inactive],
         parameters=mixture_parameters)
     mixture_crn = mixture_mixture.compile_crn()

--- a/Tests/Unit/test_parameter.py
+++ b/Tests/Unit/test_parameter.py
@@ -563,10 +563,8 @@ def test_findpath(tmp_path):
 def basic_pure(*args, **kwargs):
     """Build a legacy BasicPURE mixture, checking that it warns.
 
-    A filter set up ahead of time (whether by a pytest.mark.filterwarnings
-    decorator or by catch_warnings) does not survive here, because
-    `Mixture.compile_crn` calls `resetwarnings`.  Catching the warning at
-    the point it is raised avoids that.
+    Catching the warning here keeps it out of the test output and checks
+    that it is still raised, which simply ignoring it would not.
 
     """
     import biocrnpyler as bcp

--- a/Tests/Unit/test_plotting.py
+++ b/Tests/Unit/test_plotting.py
@@ -304,3 +304,50 @@ def test_plot_all_species_containing_accepts_strings():
     assert labels() == ['protein[GFP]']
 
     plt.close('all')
+
+
+def test_plot_gene_expression_data_with_missing_species():
+    """Panels whose species are not in the CRN are left empty."""
+    import matplotlib
+
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from biocrnpyler.utils.plotting import plot_gene_expression_data
+
+    assembly = bcp.DNAassembly(
+        'lacZ', promoter='pL', rbs='rL', protein='betagal'
+    )
+
+    def traces(mixture, gene):
+        crn = mixture.compile_crn()
+        results = {'time': np.linspace(0, 10, 5)}
+        for species in crn.species:
+            results[str(species)] = np.linspace(0, 1, 5)
+        plt.figure()
+        plot_gene_expression_data(results, crn, gene)
+        return {axes.get_title(): len(axes.lines) for axes in plt.gcf().axes}
+
+    # One-step gene expression compiles no RNA, and this mixture has none
+    # of the resources looked for either. Both panels are simply empty.
+    counts = traces(
+        bcp.ExpressionExtract(name='x', components=[assembly]), assembly
+    )
+    assert counts['DNA'] == 1
+    assert counts['RNA'] == 0
+    assert counts['Protein'] == 1
+    assert counts['Resources'] == 0
+
+    # a single gene may be given instead of a list
+    counts = traces(
+        bcp.SimpleTxTlExtract(name='x', components=[assembly]), assembly
+    )
+    assert counts['RNA'] == 1
+
+    # and a mixture that does have the resources plots them
+    counts = traces(bcp.PURE(name='x', components=[assembly]), [assembly])
+    assert counts['RNA'] > 0
+    assert counts['Resources'] == 3
+
+    plt.close('all')

--- a/Tests/Unit/test_plotting.py
+++ b/Tests/Unit/test_plotting.py
@@ -229,7 +229,8 @@ def test_render_network_bokeh():
         (None, None, 'cooperativity'): 2,
     }
     txtl = bcp.TxTlExtract(
-        'mixture1', parameters=parameters, overwrite_parameters=True)
+        'mixture1', parameters=parameters, overwrite_parameters=True
+    )
     dna = bcp.DNAassembly(
         'mydna',
         promoter=bcp.RegulatedPromoter('plac', ['laci']),
@@ -258,3 +259,48 @@ def test_render_network_bokeh():
             warnings.showwarning(
                 w.message.args[0], w.category, w.filename, w.lineno
             )
+
+
+def test_plot_all_species_containing_accepts_strings():
+    """A species may be given as a string as well as a Species."""
+    import matplotlib
+
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from biocrnpyler.utils.plotting import plot_all_species_containing
+
+    gfp_protein = Species('GFP', material_type='protein')
+    gfp_rna = Species('GFP', material_type='rna')
+    rfp_protein = Species('RFP', material_type='protein')
+    crn = bcp.ChemicalReactionNetwork(
+        species=[gfp_protein, gfp_rna, rfp_protein], reactions=[]
+    )
+
+    results = {'time': np.linspace(0, 10, 5)}
+    for species in [gfp_protein, gfp_rna, rfp_protein]:
+        results[str(species)] = np.linspace(0, 1, 5)
+
+    def labels():
+        return [
+            text.get_text() for text in plt.gca().get_legend().get_texts()
+        ]
+
+    # a string matches every species whose name contains it, and is used
+    # as the label for their total
+    plt.figure()
+    plot_all_species_containing(results, crn, 'GFP')
+    assert labels() == ['protein[GFP]', 'rna[GFP]', 'Total GFP']
+
+    # a string matching a single species labels that trace
+    plt.figure()
+    plot_all_species_containing(results, crn, 'RFP')
+    assert labels() == ['RFP']
+
+    # Species objects are still labelled by their pretty_print form
+    plt.figure()
+    plot_all_species_containing(results, crn, [gfp_protein])
+    assert labels() == ['protein[GFP]']
+
+    plt.close('all')

--- a/Tests/Unit/test_pure.py
+++ b/Tests/Unit/test_pure.py
@@ -157,17 +157,39 @@ def test_pure_species_names_can_be_changed():
     assert 'metabolite_NTPs' not in names
 
 
-@pytest.mark.xfail(
-    reason="ATP production and degradation parameters in "
-    "pure_parameters.tsv are keyed to the part_ids ATP_production and "
-    "ATP_degradation, so renaming atp orphans them",
-    raises=ValueError,
-    strict=True,
-)
-def test_pure_atp_name_can_be_changed():
-    PURE(
-        name='renamed', components=[make_gene()], atp='Energy'
-    ).compile_crn()
+def test_pure_atp_name_requires_its_own_parameters():
+    # Parameters are keyed by species name, so renaming the energy carrier
+    # orphans the ATP_production and ATP_degradation entries shipped with
+    # the mixture.  That should be an error rather than a model that is
+    # quietly missing its energy pathway.
+    with pytest.raises(ValueError, match='Energy_production'):
+        PURE(
+            name='renamed', components=[make_gene()], atp='Energy'
+        ).compile_crn()
+
+    # Supplying replacements for the new name resolves it
+    mixture = PURE(
+        name='renamed',
+        components=[make_gene()],
+        atp='Energy',
+        parameters={
+            ('one_step_pathway', 'Energy_production', 'k'): 0.02,
+            ('one_step_pathway', 'Energy_degradation', 'k'): 0.0000177,
+            ('initial concentration', None, 'Energy'): 1000,
+        },
+    )
+    names = species_names(mixture)
+    assert 'metabolite_Energy' in names
+    assert 'metabolite_ATP' not in names
+
+    # The initial concentration has to be given for the new name too
+    initial = {
+        str(key): getattr(value, 'value', value)
+        for key, value in (
+            mixture.compile_crn().initial_concentration_dict or {}
+        ).items()
+    }
+    assert initial['metabolite_Energy'] == 1000
 
 
 def test_basic_pure_is_deprecated():

--- a/Tests/Unit/test_pure.py
+++ b/Tests/Unit/test_pure.py
@@ -1,0 +1,196 @@
+#  Copyright (c) 2025, Build-A-Cell. All rights reserved.
+#  See LICENSE file in the project root directory for details.
+
+import pytest
+
+from biocrnpyler import PURE, BasicPURE, DNAassembly
+
+
+def make_gene():
+    return DNAassembly('GFP', promoter='pconst', rbs='RBS', protein='GFP')
+
+
+def species_names(mixture):
+    return {str(species) for species in mixture.compile_crn().species}
+
+
+def mechanism_names(mixture):
+    return {
+        key: type(mixture.mechanisms[key]).__name__
+        for key in ('transcription', 'translation')
+    }
+
+
+def test_pure_without_machinery():
+    # With everything turned off, expression is a simple two step process
+    mixture = PURE(
+        name='simple',
+        components=[make_gene()],
+        include_machinery=False,
+        include_resources=False,
+        include_fuel=False,
+    )
+    assert mechanism_names(mixture) == {
+        'transcription': 'SimpleTranscription',
+        'translation': 'SimpleTranslation',
+    }
+
+    # No machinery, resources, or energy carriers are created
+    assert mixture.atp is None
+    assert mixture.adp is None
+    assert mixture.fuel is None
+    assert species_names(mixture) == {'dna_GFP', 'rna_GFP', 'protein_GFP'}
+
+
+def test_pure_with_machinery():
+    # Machinery adds RNAP and ribosome, and switches to MM kinetics
+    mixture = PURE(
+        name='machinery',
+        components=[make_gene()],
+        include_machinery=True,
+        include_resources=False,
+        include_fuel=False,
+    )
+    assert mechanism_names(mixture) == {
+        'transcription': 'Transcription_MM',
+        'translation': 'Translation_MM',
+    }
+
+    names = species_names(mixture)
+    assert 'protein_RNAP' in names
+    assert 'protein_Ribo' in names
+
+    # Resources and energy carriers are still absent
+    assert 'metabolite_NTPs' not in names
+    assert 'metabolite_ATP' not in names
+    assert mixture.atp is None
+
+
+def test_pure_with_resources():
+    # Resources add NTPs and amino acids, and switch to energy mechanisms
+    mixture = PURE(
+        name='resources',
+        components=[make_gene()],
+        include_machinery=True,
+        include_resources=True,
+        include_fuel=False,
+    )
+    assert mechanism_names(mixture) == {
+        'transcription': 'Energy_Transcription_MM',
+        'translation': 'Energy_Translation_MM',
+    }
+
+    names = species_names(mixture)
+    assert 'metabolite_NTPs' in names
+    assert 'metabolite_AAs' in names
+
+    # Energy carriers require include_fuel
+    assert 'metabolite_ATP' not in names
+    assert mixture.atp is None
+
+
+def test_pure_with_fuel():
+    # Fuel adds the energy carriers, which are regenerated from the fuel
+    mixture = PURE(
+        name='fuel',
+        components=[make_gene()],
+        include_machinery=True,
+        include_resources=True,
+        include_fuel=True,
+    )
+    names = species_names(mixture)
+    assert 'metabolite_ATP' in names
+    assert 'metabolite_ADP' in names
+    assert 'metabolite_Fuel_CP' in names
+
+    assert mixture.atp is not None
+    assert mixture.adp is not None
+    assert mixture.fuel is not None
+
+
+def test_pure_switches_are_nested():
+    # Each switch requires the ones before it
+    with pytest.raises(ValueError, match='include_fuel requires'):
+        PURE(
+            name='bad',
+            components=[make_gene()],
+            include_machinery=True,
+            include_resources=False,
+            include_fuel=True,
+        )
+
+    with pytest.raises(ValueError, match='include_resources requires'):
+        PURE(
+            name='bad',
+            components=[make_gene()],
+            include_machinery=False,
+            include_resources=True,
+            include_fuel=False,
+        )
+
+
+def test_pure_species_names_can_be_changed():
+    # Each species name argument is used to name the species that is created
+    mixture = PURE(
+        name='renamed',
+        components=[make_gene()],
+        rnap='T7',
+        ribosome='Ribosome',
+        ntps='NTP',
+        amino_acids='AminoAcids',
+        adp='SpentEnergy',
+        fuel='CreatinePhosphate',
+    )
+    names = species_names(mixture)
+    for expected in [
+        'protein_T7',
+        'protein_Ribosome',
+        'metabolite_NTP',
+        'metabolite_AminoAcids',
+        'metabolite_SpentEnergy',
+        'metabolite_CreatinePhosphate',
+    ]:
+        assert expected in names
+
+    # The defaults should no longer be present
+    assert 'protein_RNAP' not in names
+    assert 'metabolite_NTPs' not in names
+
+
+@pytest.mark.xfail(
+    reason="ATP production and degradation parameters in "
+    "pure_parameters.tsv are keyed to the part_ids ATP_production and "
+    "ATP_degradation, so renaming atp orphans them",
+    raises=ValueError,
+    strict=True,
+)
+def test_pure_atp_name_can_be_changed():
+    PURE(
+        name='renamed', components=[make_gene()], atp='Energy'
+    ).compile_crn()
+
+
+def test_basic_pure_is_deprecated():
+    # BasicPURE warns, but still builds the same model as PURE
+    with pytest.warns(DeprecationWarning, match='BasicPURE is deprecated'):
+        legacy = BasicPURE(name='legacy', components=[make_gene()])
+
+    current = PURE(
+        name='legacy',
+        components=[make_gene()],
+        include_machinery=True,
+        include_resources=True,
+        include_fuel=True,
+    )
+    assert species_names(legacy) == species_names(current)
+
+
+def test_basic_pure_forwards_species_names():
+    # Species names given to BasicPURE are passed through to PURE
+    with pytest.warns(DeprecationWarning):
+        mixture = BasicPURE(
+            name='legacy', components=[make_gene()], ribosome='Ribosome'
+        )
+    names = species_names(mixture)
+    assert 'protein_Ribosome' in names
+    assert 'protein_Ribo' not in names

--- a/Tests/Unit/test_pure.py
+++ b/Tests/Unit/test_pure.py
@@ -28,7 +28,7 @@ def test_pure_without_machinery():
         components=[make_gene()],
         include_machinery=False,
         include_resources=False,
-        include_fuel=False,
+        include_energy=False,
     )
     assert mechanism_names(mixture) == {
         'transcription': 'SimpleTranscription',
@@ -49,7 +49,7 @@ def test_pure_with_machinery():
         components=[make_gene()],
         include_machinery=True,
         include_resources=False,
-        include_fuel=False,
+        include_energy=False,
     )
     assert mechanism_names(mixture) == {
         'transcription': 'Transcription_MM',
@@ -73,7 +73,7 @@ def test_pure_with_resources():
         components=[make_gene()],
         include_machinery=True,
         include_resources=True,
-        include_fuel=False,
+        include_energy=False,
     )
     assert mechanism_names(mixture) == {
         'transcription': 'Energy_Transcription_MM',
@@ -84,7 +84,7 @@ def test_pure_with_resources():
     assert 'metabolite_NTPs' in names
     assert 'metabolite_AAs' in names
 
-    # Energy carriers require include_fuel
+    # Energy carriers require include_energy
     assert 'metabolite_ATP' not in names
     assert mixture.atp is None
 
@@ -96,7 +96,7 @@ def test_pure_with_fuel():
         components=[make_gene()],
         include_machinery=True,
         include_resources=True,
-        include_fuel=True,
+        include_energy=True,
     )
     names = species_names(mixture)
     assert 'metabolite_ATP' in names
@@ -110,13 +110,13 @@ def test_pure_with_fuel():
 
 def test_pure_switches_are_nested():
     # Each switch requires the ones before it
-    with pytest.raises(ValueError, match='include_fuel requires'):
+    with pytest.raises(ValueError, match='include_energy requires'):
         PURE(
             name='bad',
             components=[make_gene()],
             include_machinery=True,
             include_resources=False,
-            include_fuel=True,
+            include_energy=True,
         )
 
     with pytest.raises(ValueError, match='include_resources requires'):
@@ -125,7 +125,7 @@ def test_pure_switches_are_nested():
             components=[make_gene()],
             include_machinery=False,
             include_resources=True,
-            include_fuel=False,
+            include_energy=False,
         )
 
 
@@ -202,7 +202,7 @@ def test_basic_pure_is_deprecated():
         components=[make_gene()],
         include_machinery=True,
         include_resources=True,
-        include_fuel=True,
+        include_energy=True,
     )
     assert species_names(legacy) == species_names(current)
 

--- a/Tests/Unit/test_pure.py
+++ b/Tests/Unit/test_pure.py
@@ -192,8 +192,31 @@ def test_pure_atp_name_requires_its_own_parameters():
     assert initial['metabolite_Energy'] == 1000
 
 
+def test_pure_without_regeneration():
+    # fuel=None keeps ATP consumption but drops the regeneration pathway
+    mixture = PURE(name='noregen', components=[make_gene()], fuel=None)
+
+    names = species_names(mixture)
+    assert 'metabolite_ATP' in names
+    assert 'metabolite_ADP' in names
+    assert not any('Fuel' in name for name in names)
+
+    assert mixture.atp is not None
+    assert mixture.adp is not None
+    assert mixture.fuel is None
+
+    # ATP keeps its initial concentration, and gains no pathway reactions
+    # of its own, so the ATP_production parameters are never needed
+    crn = mixture.compile_crn()
+    initial = {
+        str(key): getattr(value, 'value', value)
+        for key, value in (crn.initial_concentration_dict or {}).items()
+    }
+    assert initial['metabolite_ATP'] == 1000
+
+
 def test_basic_pure_is_deprecated():
-    # BasicPURE warns, but still builds the same model as PURE
+    # BasicPURE warns, and builds PURE without the regeneration pathway
     with pytest.warns(DeprecationWarning, match='BasicPURE is deprecated'):
         legacy = BasicPURE(name='legacy', components=[make_gene()])
 
@@ -203,8 +226,41 @@ def test_basic_pure_is_deprecated():
         include_machinery=True,
         include_resources=True,
         include_energy=True,
+        fuel=None,
     )
     assert species_names(legacy) == species_names(current)
+
+    # and so has no fuel species, unlike PURE's default
+    assert not any('Fuel' in name for name in species_names(legacy))
+
+
+def test_basic_pure_fuel_names_the_carrier():
+    # In BasicPURE, fuel names the energy carrier, as it did before PURE
+    # was introduced; it is an alias for PURE's atp argument
+    with pytest.warns(DeprecationWarning):
+        legacy = BasicPURE(
+            name='legacy', components=[make_gene()], fuel='ATP'
+        )
+    assert 'metabolite_ATP' in species_names(legacy)
+
+    with pytest.warns(DeprecationWarning):
+        by_fuel = BasicPURE(
+            name='a', components=[make_gene()], fuel='GTP',
+            parameters={('initial concentration', None, 'GTP'): 1000},
+        )
+    with pytest.warns(DeprecationWarning):
+        by_atp = BasicPURE(
+            name='a', components=[make_gene()], atp='GTP',
+            parameters={('initial concentration', None, 'GTP'): 1000},
+        )
+    assert species_names(by_fuel) == species_names(by_atp)
+
+    # Giving both is an error rather than one silently winning
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match='not both'):
+            BasicPURE(
+                name='a', components=[make_gene()], fuel='X', atp='Y'
+            )
 
 
 def test_basic_pure_forwards_species_names():

--- a/Tests/Unit/test_species.py
+++ b/Tests/Unit/test_species.py
@@ -78,6 +78,22 @@ class TestSpecies(TestCase):
         self.assertTrue(species.position is None)
         self.assertTrue(species.direction is None)
 
+    def test_attributes_as_string(self):
+        # a single attribute passed as a string is treated as one attribute,
+        # not split into one attribute per character
+        species = Species(name='test_species', attributes='Passive')
+        self.assertEqual(['Passive'], species.attributes)
+
+        # a string attribute gives the same species as the equivalent list
+        self.assertEqual(
+            Species(name='a', material_type='m', attributes='Passive'),
+            Species(name='a', material_type='m', attributes=['Passive']),
+        )
+
+        # other iterables are still expanded into separate attributes
+        species = Species(name='test_species', attributes=('atr1', 'atr2'))
+        self.assertEqual(['atr1', 'atr2'], species.attributes)
+
     def test_add_attribute(self):
         species = Species(name='test_species')
         # an attribute must be a string

--- a/biocrnpyler/__init__.py
+++ b/biocrnpyler/__init__.py
@@ -11,6 +11,10 @@ from .mixtures import *
 
 # All utilities
 from .utils import *
+from .utils.plotting import plot_all_containing as plot_all_containing
+from .utils.plotting import (
+    plot_gene_expression_data as plot_gene_expression_data,
+)
 
 try:
     from ._version import version as __version__

--- a/biocrnpyler/__init__.py
+++ b/biocrnpyler/__init__.py
@@ -11,11 +11,9 @@ from .mixtures import *
 
 # All utilities
 from .utils import *
-from .utils.plotting import (
-    plot_all_species_containing as plot_all_species_containing,
-)
-from .utils.plotting import (
-    plot_gene_expression_data as plot_gene_expression_data,
+from .utils.plotting import (  # noqa: F401
+    plot_all_species_containing,
+    plot_gene_expression_data,
 )
 
 try:

--- a/biocrnpyler/__init__.py
+++ b/biocrnpyler/__init__.py
@@ -11,7 +11,9 @@ from .mixtures import *
 
 # All utilities
 from .utils import *
-from .utils.plotting import plot_all_containing as plot_all_containing
+from .utils.plotting import (
+    plot_all_species_containing as plot_all_species_containing,
+)
 from .utils.plotting import (
     plot_gene_expression_data as plot_gene_expression_data,
 )

--- a/biocrnpyler/components/basic.py
+++ b/biocrnpyler/components/basic.py
@@ -7,7 +7,7 @@ from ..core.component import Component
 from ..core.reaction import Reaction
 from ..core.species import Complex, Species
 from ..mechanisms.binding import One_Step_Binding
-from ..mechanisms.enzyme import BasicCatalysis
+from ..mechanisms.enzyme import MichaelisMenten
 from ..mechanisms.metabolite import OneStepPathway
 
 
@@ -794,7 +794,7 @@ class Enzyme(Component):
         Component.__init__(
             self=self,
             name=self.enzyme.name,
-            default_mechanism=BasicCatalysis(),
+            default_mechanism=MichaelisMenten(),
             **kwargs,
         )
 

--- a/biocrnpyler/components/basic.py
+++ b/biocrnpyler/components/basic.py
@@ -6,6 +6,9 @@ from typing import List, Union
 from ..core.component import Component
 from ..core.reaction import Reaction
 from ..core.species import Complex, Species
+from ..mechanisms.binding import One_Step_Binding
+from ..mechanisms.enzyme import BasicCatalysis
+from ..mechanisms.metabolite import OneStepPathway
 
 
 class DNA(Component):
@@ -402,7 +405,17 @@ class Metabolite(Component):
                 else:
                     self.products.append(self.set_species(p))
 
-        Component.__init__(self=self, name=name, **kwargs)
+        if precursors is not None or products is not None:
+            default_mechanism = OneStepPathway()
+        else:
+            default_mechanism = None
+
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=default_mechanism,
+            **kwargs,
+        )
 
     def get_species(self) -> Species:
         """Get the metabolite species.
@@ -602,7 +615,12 @@ class ChemicalComplex(Component):
         if name is None:
             name = self.species.name
 
-        Component.__init__(self=self, name=name, **kwargs)
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=One_Step_Binding(),
+            **kwargs,
+        )
 
     def get_species(self) -> List[Species]:
         """Get the complex species.
@@ -773,7 +791,12 @@ class Enzyme(Component):
         self.substrates = substrates
         self.products = products
 
-        Component.__init__(self=self, name=self.enzyme.name, **kwargs)
+        Component.__init__(
+            self=self,
+            name=self.enzyme.name,
+            default_mechanism=BasicCatalysis(),
+            **kwargs,
+        )
 
     @property
     def substrates(self) -> List:

--- a/biocrnpyler/components/combinatorial_conformation.py
+++ b/biocrnpyler/components/combinatorial_conformation.py
@@ -140,8 +140,12 @@ class CombinatorialConformation(Component):
 
         if name is None:
             name = str(self.internal_polymer.name)
-        Component.__init__(self, name=name, **kwargs)
-        self.add_mechanism(One_Step_Reversible_Conformation_Change())
+        Component.__init__(
+            self,
+            name=name,
+            default_mechanism=One_Step_Reversible_Conformation_Change(),
+            **kwargs,
+        )
 
     # Helper function to assert the correct class type
     def _assert_conformation(self, states, input_name='states'):

--- a/biocrnpyler/components/membrane.py
+++ b/biocrnpyler/components/membrane.py
@@ -7,6 +7,14 @@ from typing import Union
 from ..core.compartment import Compartment
 from ..core.component import Component
 from ..core.species import Species
+from ..mechanisms.signaling import Membrane_Signaling_Pathway_MM
+from ..mechanisms.transport import (
+    Facilitated_Transport_MM,
+    Membrane_Protein_Integration,
+    Primary_Active_Transport_MM,
+    Simple_Diffusion,
+    Simple_Transport,
+)
 
 
 class DiffusibleMolecule(Component):
@@ -108,7 +116,11 @@ class DiffusibleMolecule(Component):
             name = self.substrate.name + '_' + self.substrate.compartment.name
 
         Component.__init__(
-            self=self, name=name, attributes=attributes, **kwargs
+            self=self,
+            name=name,
+            attributes=attributes,
+            default_mechanism=Simple_Diffusion(),
+            **kwargs,
         )
 
     def get_species(self):
@@ -334,7 +346,12 @@ class IntegralMembraneProtein(Component):
             + self.membrane_protein.compartment.name
         )
 
-        Component.__init__(self=self, name=name, **kwargs)
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=Membrane_Protein_Integration(),
+            **kwargs,
+        )
 
     def get_species(self):
         """Get the membrane protein species before insertion.
@@ -504,7 +521,7 @@ class MembraneChannel(Component):
             integral_membrane_protein = self.set_species(
                 integral_membrane_protein,
                 material_type='protein',
-                attributes='Passive' if direction is None else direction,
+                attributes=['Passive'] if direction is None else direction,
             )
         self.integral_membrane_protein = integral_membrane_protein
 
@@ -568,7 +585,12 @@ class MembraneChannel(Component):
             + self.integral_membrane_protein.compartment.name
         )
 
-        Component.__init__(self=self, name=name, **kwargs)
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=Simple_Transport(),
+            **kwargs,
+        )
 
     def get_species(self):
         """Get the integral membrane protein species.
@@ -782,14 +804,14 @@ class MembranePump(Component):
                 self.membrane_pump = self.set_species(
                     membrane_pump,
                     material_type='protein',
-                    attributes='Passive',
+                    attributes=['Passive'],
                 )
                 self.membrane_pump.ATP = ATP
             else:
                 self.membrane_pump = self.set_species(
                     membrane_pump,
                     material_type='protein',
-                    attributes=direction,
+                    attributes=[direction],
                 )
                 self.membrane_pump.ATP = ATP
                 if direction == 'Importer':
@@ -812,19 +834,19 @@ class MembranePump(Component):
                 self.integral_membrane_protein = self.set_species(
                     membrane_pump,
                     material_type='protein',
-                    attributes='Passive',
+                    attributes=['Passive'],
                 )
             elif membrane_pump.attributes[0] == 'Exporter':
                 self.membrane_pump = self.set_species(
                     membrane_pump,
                     material_type='protein',
-                    attributes='Exporter',
+                    attributes=['Exporter'],
                 )
             elif membrane_pump.attributes[0] == 'Importer':
                 self.membrane_pump = self.set_species(
                     membrane_pump,
                     material_type='protein',
-                    attributes='Importer',
+                    attributes=['Importer'],
                 )
                 self.energy = self.set_species(
                     'ATP',
@@ -867,7 +889,18 @@ class MembranePump(Component):
             + self.membrane_pump.compartment.name
         )
 
-        Component.__init__(self=self, name=name, **kwargs)
+        # Determine the default mechanism
+        if 'Passive' in self.membrane_pump.attributes:
+            default_mechanism = Primary_Active_Transport_MM()
+        else:
+            default_mechanism = Facilitated_Transport_MM()
+
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=default_mechanism,
+            **kwargs,
+        )
 
     def get_species(self):
         """Get the membrane pump protein species.
@@ -1137,7 +1170,12 @@ class MembraneSensor(Component):
             + self.membrane_sensor_protein.compartment.name
         )
 
-        Component.__init__(self=self, name=name, **kwargs)
+        Component.__init__(
+            self=self,
+            name=name,
+            default_mechanism=Membrane_Signaling_Pathway_MM(),
+            **kwargs,
+        )
 
     def get_species(self):
         """Get the membrane sensor protein species.

--- a/biocrnpyler/core/chemical_reaction_network.py
+++ b/biocrnpyler/core/chemical_reaction_network.py
@@ -604,7 +604,7 @@ class ChemicalReactionNetwork(object):
         return x0
 
     def get_all_species_containing(
-        self, species: Species, return_as_strings=False
+        self, species: Union[Species, str], return_as_strings=False
     ):
         """Find all species (complexes) that contain a given species.
 
@@ -613,8 +613,9 @@ class ChemicalReactionNetwork(object):
 
         Parameters
         ----------
-        species : Species
-            The species to search for within other species.
+        species : Species or str
+            The species to search for within other species.  If given as a
+            string, returns all species with that string as part of the name.
         return_as_strings : bool, default=False
             If True, returns species as string representations. If False,
             returns actual Species objects.
@@ -645,13 +646,15 @@ class ChemicalReactionNetwork(object):
 
         """
         return_list = []
-        if not isinstance(species, Species):
+        if not isinstance(species, (Species, str)):
             raise ValueError(
-                "species argument must be an instance of Species!"
+                "species argument must be an instance of Species or str."
             )
 
         for s in self._species:
-            if species in s.get_species(recursive=True):
+            if (
+                isinstance(species, str) and species in s.name
+            ) or species in s.get_species(recursive=True):
                 if return_as_strings:
                     return_list.append(repr(s))
                 else:

--- a/biocrnpyler/core/component.py
+++ b/biocrnpyler/core/component.py
@@ -54,6 +54,8 @@ class Component:
     initial_condition_dictionary : dict, optional
         Dictionary mapping species (or species names) to initial concentration
         values for components with multiple species.
+    default_mechanism : Mechanism, optional
+        Default mechanism to use if no other mechanisms are provided.
 
     Attributes
     ----------
@@ -120,11 +122,15 @@ class Component:
         # None, self.name):initial_concentration
         initial_concentration=None,
         initial_condition_dictionary=None,
+        default_mechanism=None,
     ):
         if mechanisms is None:
             self.mechanisms = {}
+            self.default_mechanism = default_mechanism
         else:
             self.mechanisms = mechanisms
+            self.default_mechanism = None
+
         if isinstance(name, Species):
             self.name = name.name
         elif isinstance(name, str):
@@ -484,6 +490,10 @@ class Component:
             return self.mechanisms[mechanism_type]
         elif self.mixture is not None:
             mech = self.mixture.get_mechanism(mechanism_type)
+
+        if mech is None and self.default_mechanism is not None:
+            mech = self.default_mechanism
+
         if mech is None and not optional_mechanism:
             raise KeyError(
                 f"Unable to find mechanism of type {mechanism_type} in "
@@ -643,7 +653,7 @@ class Component:
             Name of the parameter to retrieve.
         part_id : str, optional
             Part identifier for the parameter lookup key.
-        mechanism : str, optional
+        mechanism : str or Mechanism, optional
             Mechanism identifier for the parameter lookup key.
         return_numerical : bool, default=False
             If True, returns the numerical value. If False, returns the
@@ -688,23 +698,33 @@ class Component:
         if param is None and self.mixture is not None and check_mixture:
             param = self.mixture.get_parameter(mechanism, part_id, param_name)
 
-        # Finally, try the mechanism parameter database
-        if param is None and self.mechanisms is not None and check_mechanism:
+        # Finally, try mechanism parameter databases
+        if param is None and check_mechanism:
+            # Start with the component mechanism
             if isinstance(mechanism, Mechanism):
                 key = mechanism.mechanism_type
             else:
                 key = mechanism
 
-            if self.mechanisms.get(key, None):
+            if self.mechanisms is not None and self.mechanisms.get(key, None):
                 param = self.mechanisms[key].get_parameter(
                     mechanism, part_id, param_name
                 )
-            elif (
-                self.mixture
+
+            # Then mixture mechanisms
+            if (
+                param is None
+                and self.mixture
                 and self.mixture.mechanisms
                 and self.mixture.mechanisms.get(key, None)
             ):
                 param = self.mixture.mechanisms[key].get_parameter(
+                    mechanism, part_id, param_name
+                )
+
+            # Then the passed mechanism
+            if param is None and isinstance(mechanism, Mechanism):
+                param = mechanism.get_parameter(
                     mechanism, part_id, param_name
                 )
 

--- a/biocrnpyler/core/mixture.py
+++ b/biocrnpyler/core/mixture.py
@@ -3,7 +3,7 @@
 
 import copy
 from typing import List, Tuple, Union
-from warnings import resetwarnings, warn
+from warnings import warn
 
 from ..mechanisms.global_mechanisms import GlobalMechanism
 from .chemical_reaction_network import ChemicalReactionNetwork
@@ -1188,8 +1188,6 @@ class Mixture(object):
         ... )
 
         """
-        resetwarnings()
-
         if compartment is None and hasattr(self, 'compartment'):
             compartment = self.compartment
 

--- a/biocrnpyler/core/species.py
+++ b/biocrnpyler/core/species.py
@@ -26,9 +26,10 @@ class Species(OrderedMonomer):
     material_type : str, default=''
         Type of material (e.g., 'dna', 'rna', 'protein', 'complex').
         Required if name starts with a number. Must start with a letter.
-    attributes : list of str or None, optional
+    attributes : list of str, str, or None, optional
         List of attribute tags for the species (e.g., 'degraded',
-        'phosphorylated'). Each attribute must be alphanumeric.
+        'phosphorylated'). Each attribute must be alphanumeric.  A single
+        attribute may be given as a string instead of a one-element list.
     compartment : Compartment, str, or None, optional
         The compartment containing this species. If None, uses default
         compartment. If str, creates a new Compartment with that name.
@@ -130,7 +131,10 @@ class Species(OrderedMonomer):
         if not hasattr(self, '_attributes'):
             self._attributes = []
         if attributes is not None:
-            if not isinstance(attributes, list):
+            if isinstance(attributes, str):
+                # A bare string is a single attribute, not one per character
+                attributes = [attributes]
+            elif not isinstance(attributes, list):
                 attributes = list(attributes)
             for attribute in attributes:
                 self.add_attribute(attribute)

--- a/biocrnpyler/mechanisms/binding_parameters.tsv
+++ b/biocrnpyler/mechanisms/binding_parameters.tsv
@@ -8,24 +8,41 @@ mechanism_id	part_id	param_name	param_val	units	comments
 #
 # One step (and cooperative) binding
 #
-# The first step in various binding mechanisms is the initial binding of
-# the substrates.  We define binding and unbinding reaction rates here
-# for several different part types.  These rates are used by both 
-# 'one_step_binding' mechanisms and '
 
-# Chemical complex binding
-binding	chemical_complex	kb	100	/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
-binding	chemical_complex	ku	10	uM/sec	90% binding
+# The first step in various binding mechanisms is the initial binding
+# of the substrates.  We define binding and unbinding reaction rates
+# here for two different situations: a chemical complex and a
+# regulator (activator or repressor) binding to DNA.
+#
+# We use TetR and aTc as the "generic" case and use the rate constants
+# from the following paper:
+#
+#   [SK07] V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic
+#   Tetracycline-Inducible Regulatory Networks: Computer-Aided Design
+#   of Dynamic Phenotypes."  BMC Systems Biology 1, no. 1 (2007): 7.
+#   https://doi.org/10.1186/1752-0509-1-7.
+#
+# Table 1 presents rates for a large set of reactions (using Tc instead
+# of aTc) in units of (M s)^{-1} (converted to (uM s)^{-1} here by
+# multiplying by 1e-6.
 
-# Protein-DNA binding
-binding	dna_protein	kb	0.2	/sec	TODO
-binding	dna_protein	ku	1e-3	uM/sec	TODO
+# Chemical complex binding (aTc to TetR)
+binding	chemical_complex	kb	2.00	/uM/sec	SK07, Table 1, Reaction 6
+binding	chemical_complex	ku	0.001	/sec	SK07, Table 1, Reaction 8
+
+# Protein-DNA binding (TetR2 to DNA)
+binding	dna_protein	kb	2.86	/uM/sec	SK07, Table 1, Reaction 23
+binding	dna_protein	ku	5.11e-4	/sec	SK07, Table 1, Reaction 24
 
 # Default cooperativity
 binding		cooperativity	2		number of binding modules to bind simultaneously
 
-# Two step cooperative binding (oligimerization)
-two_step_cooperative_binding		kb1	1.0	/sec	forward rate constant for oligomerization (TODO)
-two_step_cooperative_binding		ku1	0.01	uM/sec	reverse rate constant for oligomerization (TODO)
-two_step_cooperative_binding		kb2	1.0	/sec	forward rate constant for oligomer-bindee binding (TODO)
-two_step_cooperative_binding		ku2	0.01	uM/sec	reverse rate constant for oligomer-bindee binding (TODO)
+# Two step cooperative binding:
+#   R1 (oligimerization): 2TetR --> TetR2)
+#   R2 (DNA binding): TetR2 to DNA)
+two_step_cooperative_binding		kb1	1.0e3	/uM/sec	SK07, Table 1, Reaction 2
+two_step_cooperative_binding		ku1	10	/sec	SK07, Table 1, Reaction 3
+two_step_cooperative_binding	chemical_complex	kb2	2.00	/uM/sec	SK07, Table 1, Reaction 6
+two_step_cooperative_binding	chemical_complex	ku2	0.001	/sec	SK07, Table 1, Reaction 8
+two_step_cooperative_binding	dna_protein	kb2	2.86	/uM/sec	SK07, Table 1, Reaction 23
+two_step_cooperative_binding	dna_protein	ku2	5.11e-4	/sec	SK07, Table 1, Reaction 24

--- a/biocrnpyler/mechanisms/binding_parameters.tsv
+++ b/biocrnpyler/mechanisms/binding_parameters.tsv
@@ -27,12 +27,12 @@ mechanism_id	part_id	param_name	param_val	units	comments
 # multiplying by 1e-6.
 
 # Chemical complex binding (aTc to TetR)
-binding	chemical_complex	kb	2.00	/uM/sec	SK07, Table 1, Reaction 6
-binding	chemical_complex	ku	0.001	/sec	SK07, Table 1, Reaction 8
+binding	chemical_complex	kb	2.00	/uM/sec	SK07, Table 1, R6
+binding	chemical_complex	ku	0.001	/sec	SK07, Table 1, R8
 
 # Protein-DNA binding (TetR2 to DNA)
-binding	dna_protein	kb	2.86	/uM/sec	SK07, Table 1, Reaction 23
-binding	dna_protein	ku	5.11e-4	/sec	SK07, Table 1, Reaction 24
+binding	dna_protein	kb	2.86	/uM/sec	SK07, Table 1, R23
+binding	dna_protein	ku	5.11e-4	/sec	SK07, Table 1, R24
 
 # Default cooperativity
 binding		cooperativity	2		number of binding modules to bind simultaneously

--- a/biocrnpyler/mechanisms/enzyme_parameters.tsv
+++ b/biocrnpyler/mechanisms/enzyme_parameters.tsv
@@ -6,13 +6,13 @@
 mechanism_id	part_id	param_name	param_val	units	comments
 
 # Basic (Michaelis-Menten) catalysis parameters
-catalysis		kb	100	/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
-catalysis		ku	10	uM/sec	90% binding
-# catalysis		kcat	1
+catalysis		kb	100	/uM/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
+catalysis		ku	10	/sec	90% binding
+# catalysis		kcat	1	/sec
 
 # Reversible Michaelis-Menten catalysis parameters
-catalysis		kb1	100	/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
-catalysis		ku1	10	uM/sec	90% binding
+catalysis		kb1	100	/uM/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
+catalysis		ku1	10	sec	90% binding
 catalysis		kb2	100	/sec	assuming 10 ms to diffuse across 1 um (characteristic cell size)
 catalysis		ku2	10	uM/sec	90% binding
 catalysis		kcat_rev	0.01

--- a/biocrnpyler/mechanisms/txtl.py
+++ b/biocrnpyler/mechanisms/txtl.py
@@ -1983,7 +1983,7 @@ class Energy_Translation_MM(Mechanism):
         else:
             raise ValueError("Fuels must be a list of Species!")
 
-        if all([isinstance(s, Species) for s in fuels]):
+        if all([isinstance(s, Species) for s in wastes]):
             self.wastes = wastes
         else:
             raise ValueError("wastes must be a list of Species!")

--- a/biocrnpyler/mechanisms/txtl_parameters.tsv
+++ b/biocrnpyler/mechanisms/txtl_parameters.tsv
@@ -19,7 +19,7 @@ translation		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 #
 # PositiveHillTranscription and NegativeHillTranscription
 #
-# We computing the various rates here based on the the following paper:
+# We compute the various rates here based on the the following paper:
 #
 #   [SK07] V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic
 #   Tetracycline-Inducible Regulatory Networks: Computer-Aided Design

--- a/biocrnpyler/mechanisms/txtl_parameters.tsv
+++ b/biocrnpyler/mechanisms/txtl_parameters.tsv
@@ -31,14 +31,14 @@ translation		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 # multiplying by 1e-6.  Dissociation constaints are computed by dividing
 # unbinding rate by the binding rate.
 
-transcription		K	5e-4	uM	SK07, Table 1, R8 / R6
-transcription		k	0.05	/sec	ktx from transcription_mm
+transcription		K	1.33e-3	uM	SK01 -> BFS formulas w/ RNAP = 1.3 (PURE)
+transcription		k	2.5e-2	/sec	hand-tuned to match MM in gfp_expression.py (TODO)
 transcription		n	2		cooperativity
 transcription		kleak	0.013	/sec	SK07, Table 1, R37
 
 # Transcription_MM and Translation_MM
 transcription_mm		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
-transcription_mm		kb	8.6e-6	/uM/sec	SK07, Table 1, R31
+transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
 transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 translation_mm		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 translation_mm		kb	0.1	/uM/sec	SK07, Table 1, R45
@@ -46,7 +46,7 @@ translation_mm		ku	100	/sec	SK07, Table 1, R46
 
 # Energy_Transcription_MM and Energy_Translation_MM
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
-energy_transcription_mm		kb	8.6e-6	/uM/sec	SK07, Table 1, R31
+energy_transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
 energy_transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 energy_transcription_mm		kb_ntps	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		ku_ntps	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)

--- a/biocrnpyler/mechanisms/txtl_parameters.tsv
+++ b/biocrnpyler/mechanisms/txtl_parameters.tsv
@@ -16,31 +16,45 @@ gene_expression		kexpress	19.23	/sec
 transcription		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
 translation		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 
+#
 # PositiveHillTranscription and NegativeHillTranscription
-transcription		K	1.6e-3	uM	RMM (TODO)
-transcription		k	3.25	/sec/uM	Tx_cat from Singhal (= ktx?? TODO)
+#
+# We computing the various rates here based on the the following paper:
+#
+#   [SK07] V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic
+#   Tetracycline-Inducible Regulatory Networks: Computer-Aided Design
+#   of Dynamic Phenotypes."  BMC Systems Biology 1, no. 1 (2007): 7.
+#   https://doi.org/10.1186/1752-0509-1-7.
+#
+# Table 1 presents rates for a large set of reactions (using Tc instead
+# of aTc) in units of (M s)^{-1} (converted to (uM s)^{-1} here by
+# multiplying by 1e-6.  Dissociation constaints are computed by dividing
+# unbinding rate by the binding rate.
+
+transcription		K	5e-4	uM	SK07, Table 1, R8 / R6
+transcription		k	0.05	/sec	ktx from transcription_mm
 transcription		n	2		cooperativity
-transcription		kleak	5e-6	/sec	RMM (TODO)
+transcription		kleak	0.013	/sec	SK07, Table 1, R37
 
 # Transcription_MM and Translation_MM
 transcription_mm		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
-transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{F, lac}
-transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+transcription_mm		kb	8.6e-6	/uM/sec	SK07, Table 1, R31
+transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 translation_mm		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
-translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2 (TODO)
-translation_mm		ku	0.003	/sec	Singhal et al. Table S2 (TODO)
+translation_mm		kb	0.1	/uM/sec	SK07, Table 1, R45
+translation_mm		ku	100	/sec	SK07, Table 1, R46
 
 # Energy_Transcription_MM and Energy_Translation_MM
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
-energy_transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{F, lac}
-energy_transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+energy_transcription_mm		kb	8.6e-6	/uM/sec	SK07, Table 1, R31
+energy_transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 energy_transcription_mm		kb_ntps	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		ku_ntps	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		length	1000	nt	default length of gene (for resource usage)
 
 energy_translation_mm		ktl	15	/sec	15 aa/s (rate will be divided by length)
-energy_translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2
-energy_translation_mm		ku	0.003	/sec	Singhal et al. Table S2
+energy_translation_mm		kb	0.1	/uM/sec	SK07, Table 1, R45
+energy_translation_mm		ku	100	/sec	SK07, Table 1, R46
 energy_translation_mm		kb_fuel	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		ku_fuel	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		length	300	aa	default length of a protein (for resource uasge)

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -1,6 +1,8 @@
 # pure.py - mixture model for PURE
 # RMM, 20 Sep 2025
 
+from warnings import warn
+
 from ..components.basic import Metabolite, Protein
 from ..core.mixture import Mixture
 from ..mechanisms.txtl import (
@@ -31,7 +33,8 @@ class PURE(Mixture):
         Requires `include_machinery` to be true.
     include_fuel : bool, default=True
         Include fuel component and energy utilization mechanism. Requires that
-        `include_machinery` and `include_resources` be True.
+        `include_machinery` and `include_resources` be True.  When False, the
+        `atp`, `adp`, and `fuel` components are set to None.
     rnap : str, default='RNAP'
         Name for the RNA polymerase protein species.
     ribosome : str, default='Ribo'
@@ -43,8 +46,14 @@ class PURE(Mixture):
         Name for the nucleotide diphosphate species (lumped NDPs).
     amino_acids : str, default='AAs'
         Name for the amino acid species (lumped amino acids).
-    fuel : str, default='ATP'
-        Name for the primary energy carrier species (ATP).
+    atp : str, default='ATP'
+        Name for the primary energy carrier species, consumed during
+        translation.
+    adp : str, default='ADP'
+        Name for the spent energy carrier species produced from `atp`.
+    fuel : str, default='Fuel_CP'
+        Name for the secondary fuel species that, together with `adp`,
+        regenerates `atp`.
     parameter_file : str, default='mixtures/pure_parameters.tsv'
         Path to file containing default parameter values for the PURE
         system.
@@ -62,7 +71,7 @@ class PURE(Mixture):
     amino_acids : Metabolite
         Amino acid metabolite component.
     fuel : Metabolite
-        Fuel metabolite component (ATP).
+        Secondary fuel metabolite component.
     name : str
         Name of the mixture.
 
@@ -248,6 +257,11 @@ class PURE(Mixture):
 class BasicPURE(Mixture):
     """PURE cell-free protein synthesis system with energy consumption.
 
+    .. deprecated:: 1.3.0
+        Use `PURE` instead, which covers this configuration and others.
+        `BasicPURE` is equivalent to `PURE` with `include_machinery`,
+        `include_resources`, and `include_fuel` all set to True.
+
     A mixture that models the PURE (Protein synthesis Using Recombinant
     Elements) reconstituted cell-free transcription-translation system with
     explicit representation of RNA polymerase (RNAP), ribosomes, and
@@ -272,24 +286,13 @@ class BasicPURE(Mixture):
     ----------
     name : str, default='PURE'
         Name identifier for the mixture.
-    rnap : str, default='RNAP'
-        Name for the RNA polymerase protein species.
-    ribosome : str, default='Ribo'
-        Name for the ribosome protein species.
-    ntps : str, default='NTPs'
-        Name for the nucleotide triphosphate species (lumped NTPs excluding
-        ATP).
-    ndps : str, default='NDPs'
-        Name for the nucleotide diphosphate species (lumped NDPs).
-    amino_acids : str, default='AAs'
-        Name for the amino acid species (lumped amino acids).
-    fuel : str, default='ATP'
-        Name for the primary energy carrier species (ATP).
     parameter_file : str, default='mixtures/pure_parameters.tsv'
         Path to file containing default parameter values for the PURE
         system.
     **kwargs
-        Additional keyword arguments passed to the parent Mixture class.
+        Additional keyword arguments passed to `PURE`, including the
+        species names `rnap`, `ribosome`, `ntps`, `ndps`, `amino_acids`,
+        `atp`, `adp`, and `fuel`.
 
     Attributes
     ----------
@@ -404,15 +407,14 @@ class BasicPURE(Mixture):
     def __init__(
         self,
         name='PURE',
-        rnap='RNAP',
-        ribosome='Ribo',
-        ntps='NTPs',
-        ndps='NDPs',
-        amino_acids='AAs',
-        fuel='ATP',
         parameter_file='mixtures/pure_parameters.tsv',
         **kwargs,
     ):
+        warn(
+            "BasicPURE is deprecated; use PURE instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         PURE.__init__(
             self,
             name=name,

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -31,10 +31,11 @@ class PURE(Mixture):
     include_resources : bool, default=True
         Include components and mechanisms for NTP and amino acid utilization.
         Requires `include_machinery` to be true.
-    include_fuel : bool, default=True
-        Include fuel component and energy utilization mechanism. Requires that
-        `include_machinery` and `include_resources` be True.  When False, the
-        `atp`, `adp`, and `fuel` components are set to None.
+    include_energy : bool, default=True
+        Include the energy carrier species and their utilization during
+        translation.  Requires that `include_machinery` and
+        `include_resources` be True.  When False, the `atp`, `adp`, and
+        `fuel` components are set to None.
     rnap : str, default='RNAP'
         Name for the RNA polymerase protein species.
     ribosome : str, default='Ribo'
@@ -192,7 +193,7 @@ class PURE(Mixture):
         self,
         include_machinery=True,
         include_resources=True,
-        include_fuel=True,
+        include_energy=True,
         name='PURE',
         rnap='RNAP',
         ribosome='Ribo',
@@ -215,9 +216,9 @@ class PURE(Mixture):
             'translation': SimpleTranslation(),
         }
 
-        if include_fuel:
+        if include_energy:
             if not include_resources:
-                raise ValueError("include_fuel requires include_resources")
+                raise ValueError("include_energy requires include_resources")
             self.fuel = Metabolite(fuel)
             self.adp = Metabolite(adp)
             self.atp = Metabolite(
@@ -256,7 +257,7 @@ class PURE(Mixture):
                 fuels=[self.ntps.get_species()],
                 wastes=[],
             )
-            if include_fuel:
+            if include_energy:
                 default_mechanisms['translation'] = Energy_Translation_MM(
                     ribosome=self.ribosome.get_species(),
                     fuels=4 * [self.atp.get_species()]
@@ -278,7 +279,7 @@ class BasicPURE(Mixture):
     .. deprecated:: 1.3.0
         Use `PURE` instead, which covers this configuration and others.
         `BasicPURE` is equivalent to `PURE` with `include_machinery`,
-        `include_resources`, and `include_fuel` all set to True.
+        `include_resources`, and `include_energy` all set to True.
 
     A mixture that models the PURE (Protein synthesis Using Recombinant
     Elements) reconstituted cell-free transcription-translation system with
@@ -372,6 +373,6 @@ class BasicPURE(Mixture):
             parameter_file=parameter_file,
             include_machinery=True,
             include_resources=True,
-            include_fuel=True,
+            include_energy=True,
             **kwargs,
         )

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -172,7 +172,9 @@ class PURE(Mixture):
         ntps='NTPs',
         ndps='NDPs',
         amino_acids='AAs',
-        fuel='ATP',
+        atp='ATP',
+        adp='ADP',
+        fuel='Fuel_CP',
         parameter_file='mixtures/pure_parameters.tsv',
         **kwargs,
     ):
@@ -190,8 +192,14 @@ class PURE(Mixture):
             if not include_resources:
                 raise ValueError("include_fuel requires include_resources")
             self.fuel = Metabolite(fuel)
-            self.add_components([self.fuel])
+            self.adp = Metabolite(adp)
+            self.atp = Metabolite(
+                atp, precursors=[self.fuel, self.adp], products=[self.adp]
+            )  # fuel becomes ATP, and ATP is degraded
+            self.add_components([self.atp])  # includes ADP, fuel
         else:
+            self.atp = None
+            self.adp = None
             self.fuel = None
 
         if include_machinery:
@@ -224,9 +232,9 @@ class PURE(Mixture):
             if include_fuel:
                 default_mechanisms['translation'] = Energy_Translation_MM(
                     ribosome=self.ribosome.get_species(),
-                    fuels=4 * [self.fuel.get_species()]
+                    fuels=4 * [self.atp.get_species()]
                     + [self.amino_acids.get_species()],
-                    wastes=[],
+                    wastes=4 * [self.adp.get_species()],
                 )
             else:
                 default_mechanisms['translation'] = Energy_Translation_MM(

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -116,6 +116,24 @@ class PURE(Mixture):
     - Separate tracking of ATP vs other NTPs
     - Suitable for modeling batch-mode PURE reactions
 
+    Parameters are looked up by species name, so when renaming a species
+    the values in the default `parameter_file` will no longer match, and
+    replacements have to be supplied for the new name.  For most species
+    it is only the 'initial concentration' parameter that is affected,
+    but in some cases, such as `atp`, there can also be reaction rates.
+    For example::
+
+        PURE(
+            ribosome='Ribosome',
+            atp='GTP',
+            parameters={
+                ('initial concentration', None, 'Ribosome'): 3,
+                ('initial concentration', None, 'GTP'): 1000,
+                ('one_step_pathway', 'GTP_production', 'k'): 0.02,
+                ('one_step_pathway', 'GTP_degradation', 'k'): 0.0000177,
+            },
+        )
+
     Energy model details:
 
     - Transcription: Consumes L NTPs and L ATPs per mRNA of length L
@@ -316,73 +334,6 @@ class BasicPURE(Mixture):
     Energy_Transcription_MM : Mechanism for energy-consuming transcription.
     Energy_Translation_MM : Mechanism for energy-consuming translation.
     Mixture : Base class for all mixtures.
-
-    Notes
-    -----
-    This mixture automatically adds the following components:
-
-    - RNA polymerase (RNAP)
-    - Ribosome
-    - Amino acids (lumped)
-    - NTPs (nucleotide triphosphates excluding ATP, lumped)
-    - NDPs (nucleotide diphosphates, lumped)
-    - Fuel (ATP for energy)
-
-    Default mechanisms included:
-
-    - 'transcription' : `Energy_Transcription_MM` - Michaelis-Menten
-      transcription with length-dependent ATP and NTP consumption
-    - 'translation' : `Energy_Translation_MM` - Michaelis-Menten translation
-      with length-dependent amino acid and ATP consumption
-    - 'catalysis' : `MichaelisMenten` - General Michaelis-Menten enzyme
-      catalysis for user-defined enzymatic reactions
-    - 'binding' : `One_Step_Binding` - Simple multi-species binding for
-      forming complexes
-
-    Key features of this mixture:
-
-    - Explicit modeling of PURE system components
-    - Length-dependent energy consumption (realistic stoichiometry)
-    - No fuel regeneration mechanisms (finite resource pool)
-    - Resource competition effects (genes compete for RNAP and ribosomes)
-    - Resource depletion dynamics (ATP, NTPs, amino acids deplete)
-    - Enzyme sequestration in complexes
-    - Separate tracking of ATP vs other NTPs
-    - Suitable for modeling batch-mode PURE reactions
-
-    Energy model details:
-
-    - Transcription: Consumes L NTPs and L ATPs per mRNA of length L
-    - Translation: Consumes L amino acids and 4L ATPs per protein of length
-      L (4 ATPs per amino acid reflect GTP hydrolysis during elongation)
-    - No regeneration: ATP, NTPs, and amino acids are consumed but not
-      regenerated
-    - Energy depletion: Expression stops when resources are exhausted
-    - Length parameter L: Represents gene/protein length in appropriate
-      units
-    - Lumped species: Different nucleotides lumped into NTPs, different
-      amino acids lumped into single species
-    - Separate ATP: ATP tracked separately from other NTPs for independent
-      energy accounting
-
-    Differences from `EnergyTxTlExtract`:
-
-    - No fuel regeneration pathway (no NTP regeneration from 3PGA or other
-      fuel sources)
-    - ATP modeled as separate fuel species rather than included in NTPs
-    - Default parameter file points to PURE-specific parameters
-    - Intended for modeling finite-resource batch reactions
-    - More realistic for in vitro PURE systems
-
-    Common applications include:
-
-    - PURE cell-free TX-TL systems
-    - Resource-limited gene expression modeling
-    - TX-TL system optimization with fixed resource budgets
-    - Batch mode TX-TL reactions
-    - Energy budget and resource allocation studies
-    - Multi-gene expression burden analysis
-    - In vitro synthetic biology applications
 
     Examples
     --------

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -41,8 +41,10 @@ class PURE(Mixture):
     ribosome : str, default='Ribo'
         Name for the ribosome protein species.
     ntps : str, default='NTPs'
-        Name for the nucleotide triphosphate species (lumped NTPs excluding
-        ATP).
+        Name for the nucleotide triphosphate species, lumping the four
+        nucleotides that are polymerized during transcription.  ATP is
+        counted here in its role as a monomer; `atp` tracks its separate
+        role as an energy carrier.
     ndps : str, default='NDPs'
         Name for the nucleotide diphosphate species (lumped NDPs).
     amino_acids : str, default='AAs'
@@ -69,7 +71,7 @@ class PURE(Mixture):
     ribosome : Protein
         Ribosome component.
     ntps : Metabolite
-        Nucleotide triphosphate metabolite component (excluding ATP).
+        Nucleotide triphosphate metabolite component.
     amino_acids : Metabolite
         Amino acid metabolite component.
     fuel : Metabolite
@@ -93,9 +95,9 @@ class PURE(Mixture):
     - RNA polymerase (RNAP)
     - Ribosome
     - Amino acids (lumped)
-    - NTPs (nucleotide triphosphates excluding ATP, lumped)
-    - NDPs (nucleotide diphosphates, lumped)
-    - Fuel (ATP for energy)
+    - NTPs (nucleotide triphosphates, lumped)
+    - ATP and ADP (the energy carrier and its spent form)
+    - Fuel (regenerates ATP, unless `fuel` is None)
 
     Default mechanisms included:
 
@@ -112,11 +114,12 @@ class PURE(Mixture):
 
     - Explicit modeling of PURE system components
     - Length-dependent energy consumption (realistic stoichiometry)
-    - No fuel regeneration mechanisms (finite resource pool)
+    - ATP regeneration from a finite pool of fuel, or none at all if
+      `fuel` is None
     - Resource competition effects (genes compete for RNAP and ribosomes)
     - Resource depletion dynamics (ATP, NTPs, amino acids deplete)
     - Enzyme sequestration in complexes
-    - Separate tracking of ATP vs other NTPs
+    - Separate tracking of ATP as an energy carrier and as a nucleotide
     - Suitable for modeling batch-mode PURE reactions
 
     Parameters are looked up by species name, so when renaming a species
@@ -139,24 +142,26 @@ class PURE(Mixture):
 
     Energy model details:
 
-    - Transcription: Consumes L NTPs and L ATPs per mRNA of length L
-    - Translation: Consumes L amino acids and 4L ATPs per protein of length
-      L (4 ATPs per amino acid reflect GTP hydrolysis during elongation)
-    - No regeneration: ATP, NTPs, and amino acids are consumed but not
-      regenerated
+    - Transcription: Consumes L NTPs per mRNA of length L.  The
+      nucleotides are incorporated as monomers, so no energy carrier is
+      spent beyond the nucleotides themselves
+    - Translation: Consumes L amino acids and 4L ATPs per protein of
+      length L.  The four high-energy phosphates per residue are two for
+      charging the tRNA and two for the GTP hydrolyzed during elongation,
+      all counted here as ATP
     - Energy depletion: Expression stops when resources are exhausted
     - Length parameter L: Represents gene/protein length in appropriate
       units
     - Lumped species: Different nucleotides lumped into NTPs, different
       amino acids lumped into single species
-    - Separate ATP: ATP tracked separately from other NTPs for independent
-      energy accounting
+    - Separate ATP: ATP appears in two roles, as one of the nucleotides
+      polymerized during transcription, counted in NTPs, and as the
+      energy carrier spent during translation, counted in `atp`
 
     Differences from `EnergyTxTlExtract`:
 
-    - No fuel regeneration pathway (no NTP regeneration from 3PGA or other
-      fuel sources)
-    - ATP modeled as separate fuel species rather than included in NTPs
+    - Regenerates ATP from creatine phosphate rather than from 3PGA, and
+      only when `fuel` is given
     - Default parameter file points to PURE-specific parameters
     - Intended for modeling finite-resource batch reactions
     - More realistic for in vitro PURE systems
@@ -332,7 +337,7 @@ class BasicPURE(Mixture):
     ribosome : Protein
         Ribosome component.
     ntps : Metabolite
-        Nucleotide triphosphate metabolite component (excluding ATP).
+        Nucleotide triphosphate metabolite component.
     amino_acids : Metabolite
         Amino acid metabolite component.
     atp : Metabolite

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -45,8 +45,6 @@ class PURE(Mixture):
         nucleotides that are polymerized during transcription.  ATP is
         counted here in its role as a monomer; `atp` tracks its separate
         role as an energy carrier.
-    ndps : str, default='NDPs'
-        Name for the nucleotide diphosphate species (lumped NDPs).
     amino_acids : str, default='AAs'
         Name for the amino acid species (lumped amino acids).
     atp : str, default='ATP'
@@ -205,7 +203,6 @@ class PURE(Mixture):
         rnap='RNAP',
         ribosome='Ribo',
         ntps='NTPs',
-        ndps='NDPs',
         amino_acids='AAs',
         atp='ATP',
         adp='ADP',
@@ -327,8 +324,8 @@ class BasicPURE(Mixture):
         system.
     **kwargs
         Additional keyword arguments passed to `PURE`, including the
-        species names `rnap`, `ribosome`, `ntps`, `ndps`, `amino_acids`,
-        `atp`, and `adp`.
+        species names `rnap`, `ribosome`, `ntps`, `amino_acids`, `atp`,
+        and `adp`.
 
     Attributes
     ----------

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -3,8 +3,6 @@
 
 from ..components.basic import Metabolite, Protein
 from ..core.mixture import Mixture
-from ..mechanisms.binding import One_Step_Binding
-from ..mechanisms.enzyme import MichaelisMenten
 from ..mechanisms.txtl import (
     Energy_Transcription_MM,
     Energy_Translation_MM,

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -52,9 +52,10 @@ class PURE(Mixture):
         translation.
     adp : str, default='ADP'
         Name for the spent energy carrier species produced from `atp`.
-    fuel : str, default='Fuel_CP'
+    fuel : str or None, default='Fuel_CP'
         Name for the secondary fuel species that, together with `adp`,
-        regenerates `atp`.
+        regenerates `atp`.  If None, no fuel species is created and `atp`
+        is consumed without being regenerated.
     parameter_file : str, default='mixtures/pure_parameters.tsv'
         Path to file containing default parameter values for the PURE
         system.
@@ -72,7 +73,8 @@ class PURE(Mixture):
     amino_acids : Metabolite
         Amino acid metabolite component.
     fuel : Metabolite
-        Secondary fuel metabolite component.
+        Secondary fuel metabolite component, or None if there is no
+        regeneration.
     name : str
         Name of the mixture.
 
@@ -219,12 +221,18 @@ class PURE(Mixture):
         if include_energy:
             if not include_resources:
                 raise ValueError("include_energy requires include_resources")
-            self.fuel = Metabolite(fuel)
             self.adp = Metabolite(adp)
-            self.atp = Metabolite(
-                atp, precursors=[self.fuel, self.adp], products=[self.adp]
-            )  # fuel becomes ATP, and ATP is degraded
-            self.add_components([self.atp])  # includes ADP, fuel
+            if fuel is None:
+                # ATP is consumed but never replenished
+                self.fuel = None
+                self.atp = Metabolite(atp)
+                self.add_components([self.atp, self.adp])
+            else:
+                self.fuel = Metabolite(fuel)
+                self.atp = Metabolite(
+                    atp, precursors=[self.fuel, self.adp], products=[self.adp]
+                )  # fuel becomes ATP, and ATP is degraded
+                self.add_components([self.atp])  # includes ADP, fuel
         else:
             self.atp = None
             self.adp = None
@@ -294,9 +302,9 @@ class BasicPURE(Mixture):
     resource-limited PURE systems. Different amino acids and nucleotides are
     lumped into single meta-species for simplicity.
 
-    Note that fuel (default 'ATP') is modeled as a separate molecule from
-    other nucleotides ('NTPs'), allowing independent tracking of energy
-    consumption.
+    Note that the energy carrier (default 'ATP') is modeled as a separate
+    molecule from other nucleotides ('NTPs'), allowing independent tracking
+    of energy consumption.
 
     Energy usage for transcription and translation is length-dependent,
     reflecting stoichiometric consumption during biopolymer synthesis.
@@ -305,13 +313,17 @@ class BasicPURE(Mixture):
     ----------
     name : str, default='PURE'
         Name identifier for the mixture.
+    fuel : str or None, optional
+        Name for the energy carrier species, retained for compatibility
+        with earlier versions of this mixture.  Equivalent to the `atp`
+        argument of `PURE`; giving both is an error.
     parameter_file : str, default='mixtures/pure_parameters.tsv'
         Path to file containing default parameter values for the PURE
         system.
     **kwargs
         Additional keyword arguments passed to `PURE`, including the
         species names `rnap`, `ribosome`, `ntps`, `ndps`, `amino_acids`,
-        `atp`, `adp`, and `fuel`.
+        `atp`, and `adp`.
 
     Attributes
     ----------
@@ -323,8 +335,8 @@ class BasicPURE(Mixture):
         Nucleotide triphosphate metabolite component (excluding ATP).
     amino_acids : Metabolite
         Amino acid metabolite component.
-    fuel : Metabolite
-        Fuel metabolite component (ATP).
+    atp : Metabolite
+        Energy carrier metabolite component.
     name : str
         Name of the mixture.
 
@@ -354,11 +366,20 @@ class BasicPURE(Mixture):
     ... )
     >>> crn = mixture.compile_crn()
 
+    Notes
+    -----
+    The `fuel` argument does not mean the same thing here as it does in
+    `PURE`.  In this mixture it names the energy carrier, as it did before
+    `PURE` was introduced, and is an alias for the `atp` argument of
+    `PURE`.  In `PURE` it names the species that regenerates the carrier,
+    which this mixture does not have.
+
     """
 
     def __init__(
         self,
         name='PURE',
+        fuel=None,
         parameter_file='mixtures/pure_parameters.tsv',
         **kwargs,
     ):
@@ -367,6 +388,16 @@ class BasicPURE(Mixture):
             DeprecationWarning,
             stacklevel=2,
         )
+        # Here fuel names the energy carrier, which PURE calls atp.  Note
+        # that fuel=None means "not given" in this signature, but means
+        # "no regeneration" in the call to PURE below.
+        if fuel is not None:
+            if 'atp' in kwargs:
+                raise ValueError(
+                    "BasicPURE accepts fuel or atp, not both; they name "
+                    "the same species"
+                )
+            kwargs['atp'] = fuel
         PURE.__init__(
             self,
             name=name,
@@ -374,5 +405,6 @@ class BasicPURE(Mixture):
             include_machinery=True,
             include_resources=True,
             include_energy=True,
+            fuel=None,
             **kwargs,
         )

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -5,7 +5,238 @@ from ..components.basic import Metabolite, Protein
 from ..core.mixture import Mixture
 from ..mechanisms.binding import One_Step_Binding
 from ..mechanisms.enzyme import MichaelisMenten
-from ..mechanisms.txtl import Energy_Transcription_MM, Energy_Translation_MM
+from ..mechanisms.txtl import (
+    Energy_Transcription_MM,
+    Energy_Translation_MM,
+    SimpleTranscription,
+    SimpleTranslation,
+    Transcription_MM,
+    Translation_MM,
+)
+
+
+class PURE(Mixture):
+    """PURE cell-free protein synthesis system with customizable mechanisms.
+
+    A mixture that models the PURE (Protein synthesis Using Recombinant
+    Elements) reconstituted cell-free transcription-translation system with
+    customizable mechanisms.
+
+    Parameters
+    ----------
+    name : str, default='PURE'
+        Name identifier for the mixture.
+    include_machinery : bool, default=True
+        Include components and mechanisms for RNAP and ribosomes.
+    include_resources : bool, default=True
+        Include components and mechanisms for NTP and amino acid utilization.
+        Requires `include_machinery` to be true.
+    include_fuel : bool, default=True
+        Include fuel component and energy utilization mechanism. Requires that
+        `include_machinery` and `include_resources` be True.
+    rnap : str, default='RNAP'
+        Name for the RNA polymerase protein species.
+    ribosome : str, default='Ribo'
+        Name for the ribosome protein species.
+    ntps : str, default='NTPs'
+        Name for the nucleotide triphosphate species (lumped NTPs excluding
+        ATP).
+    ndps : str, default='NDPs'
+        Name for the nucleotide diphosphate species (lumped NDPs).
+    amino_acids : str, default='AAs'
+        Name for the amino acid species (lumped amino acids).
+    fuel : str, default='ATP'
+        Name for the primary energy carrier species (ATP).
+    parameter_file : str, default='mixtures/pure_parameters.tsv'
+        Path to file containing default parameter values for the PURE
+        system.
+    **kwargs
+        Additional keyword arguments passed to the parent Mixture class.
+
+    Attributes
+    ----------
+    rnap : Protein
+        RNA polymerase component.
+    ribosome : Protein
+        Ribosome component.
+    ntps : Metabolite
+        Nucleotide triphosphate metabolite component (excluding ATP).
+    amino_acids : Metabolite
+        Amino acid metabolite component.
+    fuel : Metabolite
+        Fuel metabolite component (ATP).
+    name : str
+        Name of the mixture.
+
+    See Also
+    --------
+    EnergyTxTlExtract : TX-TL with fuel regeneration.
+    TxTlExtract : TX-TL with machinery but no energy.
+    Energy_Transcription_MM : Mechanism for energy-consuming transcription.
+    Energy_Translation_MM : Mechanism for energy-consuming translation.
+    Mixture : Base class for all mixtures.
+
+    Notes
+    -----
+    This mixture automatically adds the following components:
+
+    - RNA polymerase (RNAP)
+    - Ribosome
+    - Amino acids (lumped)
+    - NTPs (nucleotide triphosphates excluding ATP, lumped)
+    - NDPs (nucleotide diphosphates, lumped)
+    - Fuel (ATP for energy)
+
+    Default mechanisms included:
+
+    - 'transcription' : `Energy_Transcription_MM` - Michaelis-Menten
+      transcription with length-dependent ATP and NTP consumption
+    - 'translation' : `Energy_Translation_MM` - Michaelis-Menten translation
+      with length-dependent amino acid and ATP consumption
+    - 'catalysis' : `MichaelisMenten` - General Michaelis-Menten enzyme
+      catalysis for user-defined enzymatic reactions
+    - 'binding' : `One_Step_Binding` - Simple multi-species binding for
+      forming complexes
+
+    Key features of this mixture:
+
+    - Explicit modeling of PURE system components
+    - Length-dependent energy consumption (realistic stoichiometry)
+    - No fuel regeneration mechanisms (finite resource pool)
+    - Resource competition effects (genes compete for RNAP and ribosomes)
+    - Resource depletion dynamics (ATP, NTPs, amino acids deplete)
+    - Enzyme sequestration in complexes
+    - Separate tracking of ATP vs other NTPs
+    - Suitable for modeling batch-mode PURE reactions
+
+    Energy model details:
+
+    - Transcription: Consumes L NTPs and L ATPs per mRNA of length L
+    - Translation: Consumes L amino acids and 4L ATPs per protein of length
+      L (4 ATPs per amino acid reflect GTP hydrolysis during elongation)
+    - No regeneration: ATP, NTPs, and amino acids are consumed but not
+      regenerated
+    - Energy depletion: Expression stops when resources are exhausted
+    - Length parameter L: Represents gene/protein length in appropriate
+      units
+    - Lumped species: Different nucleotides lumped into NTPs, different
+      amino acids lumped into single species
+    - Separate ATP: ATP tracked separately from other NTPs for independent
+      energy accounting
+
+    Differences from `EnergyTxTlExtract`:
+
+    - No fuel regeneration pathway (no NTP regeneration from 3PGA or other
+      fuel sources)
+    - ATP modeled as separate fuel species rather than included in NTPs
+    - Default parameter file points to PURE-specific parameters
+    - Intended for modeling finite-resource batch reactions
+    - More realistic for in vitro PURE systems
+
+    Common applications include:
+
+    - PURE cell-free TX-TL systems
+    - Resource-limited gene expression modeling
+    - TX-TL system optimization with fixed resource budgets
+    - Batch mode TX-TL reactions
+    - Energy budget and resource allocation studies
+    - Multi-gene expression burden analysis
+    - In vitro synthetic biology applications
+
+    Examples
+    --------
+    Create a PURE mixture for GFP expression:
+
+    >>> gfp_gene = bcp.DNAassembly(
+    ...     name='gfp_construct',
+    ...     promoter='pconst',
+    ...     rbs='bcd2',
+    ...     transcript='gfp_mrna',
+    ...     protein='GFP'
+    ... )
+    >>> mixture = bcp.BasicPURE(
+    ...     name='pure_mixture',
+    ...     components=[gfp_gene],
+    ...     parameter_file='mixtures/pure_parameters.tsv'
+    ... )
+    >>> crn = mixture.compile_crn()
+
+    """
+
+    def __init__(
+        self,
+        include_machinery=True,
+        include_resources=True,
+        include_fuel=True,
+        name='PURE',
+        rnap='RNAP',
+        ribosome='Ribo',
+        ntps='NTPs',
+        ndps='NDPs',
+        amino_acids='AAs',
+        fuel='ATP',
+        parameter_file='mixtures/pure_parameters.tsv',
+        **kwargs,
+    ):
+        Mixture.__init__(
+            self, name=name, parameter_file=parameter_file, **kwargs
+        )
+
+        # Start with basic mechansims for transcription and translation
+        default_mechanisms = {
+            'transcription': SimpleTranscription(),
+            'translation': SimpleTranslation(),
+        }
+
+        if include_fuel:
+            if not include_resources:
+                raise ValueError("include_fuel requires include_resources")
+            self.fuel = Metabolite(fuel)
+            self.add_components([self.fuel])
+        else:
+            self.fuel = None
+
+        if include_machinery:
+            self.rnap = Protein(rnap)
+            self.ribosome = Protein(ribosome)
+            self.add_components([self.rnap, self.ribosome])
+
+            default_mechanisms |= {
+                'transcription': Transcription_MM(rnap=self.rnap.species),
+                'translation': Translation_MM(ribosome=self.ribosome.species),
+            }
+
+        if include_resources:
+            if not include_machinery:
+                raise ValueError(
+                    "include_resources requires include_machinery"
+                )
+
+            # create default Components to represent cellular machinery
+            self.ntps = Metabolite(ntps)
+            self.amino_acids = Metabolite(amino_acids)
+            self.add_components([self.amino_acids, self.ntps])
+
+            # Create default TX-TL Mechanisms
+            default_mechanisms['transcription'] = Energy_Transcription_MM(
+                rnap=self.rnap.get_species(),
+                fuels=[self.ntps.get_species()],
+                wastes=[],
+            )
+            if include_fuel:
+                default_mechanisms['translation'] = Energy_Translation_MM(
+                    ribosome=self.ribosome.get_species(),
+                    fuels=4 * [self.fuel.get_species()]
+                    + [self.amino_acids.get_species()],
+                    wastes=[],
+                )
+            else:
+                default_mechanisms['translation'] = Energy_Translation_MM(
+                    ribosome=self.ribosome.get_species(),
+                    fuels=[self.amino_acids.get_species()],
+                    wastes=[],
+                )
+        self.add_mechanisms(mechanisms=default_mechanisms, overwrite=False)
 
 
 class BasicPURE(Mixture):
@@ -176,45 +407,12 @@ class BasicPURE(Mixture):
         parameter_file='mixtures/pure_parameters.tsv',
         **kwargs,
     ):
-        Mixture.__init__(
-            self, name=name, parameter_file=parameter_file, **kwargs
+        PURE.__init__(
+            self,
+            name=name,
+            parameter_file=parameter_file,
+            include_machinery=True,
+            include_resources=True,
+            include_fuel=True,
+            **kwargs,
         )
-
-        # create default Components to represent cellular machinery
-        self.rnap = Protein(rnap)
-        self.ribosome = Protein(ribosome)
-        self.ntps = Metabolite(ntps)
-        self.amino_acids = Metabolite(amino_acids)
-        self.fuel = Metabolite(fuel)
-
-        default_components = [
-            self.rnap,
-            self.ribosome,
-            self.amino_acids,
-            self.ntps,
-            self.fuel,
-        ]
-        self.add_components(default_components)
-
-        # Create default TX-TL Mechanisms
-        mech_tx = Energy_Transcription_MM(
-            rnap=self.rnap.get_species(),
-            fuels=[self.ntps.get_species()],
-            wastes=[],
-        )
-        mech_tl = Energy_Translation_MM(
-            ribosome=self.ribosome.get_species(),
-            fuels=4 * [self.fuel.get_species()]
-            + [self.amino_acids.get_species()],
-            wastes=[],
-        )
-        mech_cat = MichaelisMenten()
-        mech_bind = One_Step_Binding()
-
-        default_mechanisms = {
-            mech_tx.mechanism_type: mech_tx,
-            mech_tl.mechanism_type: mech_tl,
-            mech_cat.mechanism_type: mech_cat,
-            mech_bind.mechanism_type: mech_bind,
-        }
-        self.add_mechanisms(default_mechanisms, overwrite=None)

--- a/biocrnpyler/mixtures/pure_parameters.tsv
+++ b/biocrnpyler/mixtures/pure_parameters.tsv
@@ -39,6 +39,12 @@ initial concentration		ATP	1000	uM	[ATP/GTP] - [CTP/UTP]
 initial concentration		NTPs	4000	uM	[CTP/UTP] * 4 (NTPs)
 initial concentration		AAs	6000	uM	0.3 mM (upper bound) * 20 AAs
 
+transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{Flac}
+transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+
+translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2
+translation_mm		ku	0.003	/sec	Singhal et al. Table S2
+
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
 energy_transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{Flac}
 energy_transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)

--- a/biocrnpyler/mixtures/pure_parameters.tsv
+++ b/biocrnpyler/mixtures/pure_parameters.tsv
@@ -58,3 +58,8 @@ energy_translation_mm		ku	0.003	/sec	Singhal et al. Table S2
 energy_translation_mm		kb_fuel	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		ku_fuel	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		length	300	aa	default length of a protein (for resource uasge)
+
+# Parameters for energy regeneration
+initial concentration		Fuel_CP	16666	uM	50 mM small molecule * 3/10 in final mix
+one_step_pathway	ATP_production	k	0.02	/uM/sec	alpha_atp, Singhal et al. Table S2 (TODO)
+one_step_pathway	ATP_degradation	k	0.0000177	/sec	Delta_ATP, Singhal et al. Table S2 (TODO)

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -27,7 +27,7 @@ from ..core.component import Component
 from ..core.polymer import OrderedPolymer
 from ..core.propensities import MassAction
 from ..core.species import ComplexSpecies, Species
-from ..utils.units import mins
+from ..utils.units import mins, nM, uM, mM
 from . import member_dictionary_search
 
 HAVE_MATPLOTLIB = False
@@ -1358,52 +1358,101 @@ def render_network_bokeh(
     return plot
 
 
-def plot_all_containing(
+def plot_all_species_containing(
     results,
     crn,
     species_list,
     time_units=mins,
+    time_label='min',
+    concentration_units=uM,
+    concentration_label='uM',
     legend_fontsize='small',
     show_material=True,
+    plot_total=True,
+    trace_offset=0,
 ):
+    """Plot time responses for all species containing a given species.
+
+    Generate a plot showing the concentrations of all species that contain
+    a given species (or list of species), including complexes.
+
+    Parameters
+    ----------
+    results : DataFrame
+        Pandas dataframe containing the simulation results.
+    crn : ChemicalReactionNetwork
+        CRN being simulutated (used to determine species names).
+    species_list : List of Species or str
+        Species to be used to determine full list of species to plot.
+    time_units : float
+        Time units factor used to convert from seconds to desired unit.
+    legend_fontsize : str, default='small'
+        Font size to use for the legend.
+    show_material : bool, default=True
+        Include the material type in the legend string.
+    plot_total : bool, default=True
+        Plot the total concentration in addition to individual species.
+    trace_offset : float, default=0
+        Value to use in offseting traces, to avoid overlap.
+    """
+
     if not isinstance(species_list, (list, tuple)):
         species_list = [species_list]
 
     timepts = results['time'] / time_units
+    offset = 0
     for species in species_list:
         if isinstance(species, Component):
             species = species.species
 
         compounds = crn.get_all_species_containing(species)
-        if len(compounds) > 1:
+        if len(compounds) == 0:
+            warn(f"No compounds found with species {species}")
+            return
+        elif len(compounds) > 1:
             species_total = np.zeros(results['time'].size)
             for compound in compounds:
                 plt.plot(
                     timepts,
-                    results[str(compound)],
+                    results[str(compound)] / concentration_units + offset,
                     label=compound.pretty_print(show_material=show_material),
                 )
                 species_total += results[str(compound)]
-            plt.plot(
-                timepts,
-                species_total,
-                label=f"Total {species.pretty_print()}",
-            )
+                offset += trace_offset
+            if plot_total:
+                plt.plot(
+                    timepts,
+                    species_total / concentration_units,
+                    label=f"Total {species.pretty_print()}",
+                )
+                offset += trace_offset
         else:
             plt.plot(
                 timepts,
-                results[str(compounds[0])],
+                results[str(compounds[0])] / concentration_units,
                 label=species.pretty_print(),
             )
-        plt.legend(fontsize=legend_fontsize)
-        plt.ylabel("Concentration [uM]")
+            offset += trace_offset
+
+    plt.legend(fontsize=legend_fontsize)
+    plt.xlabel(f"Time [{time_label}]")
+    plt.ylabel(f"Concentration [{concentration_label}]")
 
 
 def plot_gene_expression_data(
     results,
     crn,
-    genelist,
-    plot_totals=None,
+    gene_list,
+    time_units=mins,
+    time_label='min',
+    concentration_units=[nM, uM, uM, mM],
+    concentration_label=['nM', 'uM', 'uM', 'mM'],
+    legend_fontsize='x-small',
+    title_fontsize='small',
+    show_material=True,
+    plot_total=True,
+    trace_offset=0,
+    resource_labels=['metabolite_AAs', 'metabolite_NTPs', 'metabolite_ATP'],
 ):
     """Plot DNA, RNA, and protein concentrations for a list of genes.
 
@@ -1412,42 +1461,80 @@ def plot_gene_expression_data(
 
     Parameters
     ----------
-    results :
-
+    results : DataFrame
+        Pandas dataframe containing the simulation results.
+    crn : ChemicalReactionNetwork
+        CRN being simulutated (used to determine species names).
+    gene_list : List of Species or str
+        Genes to be used to determine full list of species to plot.
+    time_units : float, default=bcp.units.mins
+        Units factor used to plot scale time.
+    time_label : str, default='min'
+        String to use in time axis label
+    concentration_units : float or list of float, default=[nM, uM, uM, mM]
+        Units factor to scale concentrations of DNA, RNA, protein, resources.
+    concentration_label : str or list of str, default=['nM', 'uM', 'uM', 'mM']
+        Strings to use in labels for DNA, RNA, protein, resources.
+    legend_fontsize : str, default='x-small'
+        Font size to use for the legend.
+    title_fontsize : str, default='small'
+        Font size to use for individual panel titles.
+    show_material : bool, default=True
+        Include the material type in the legend string.
+    plot_total : bool or list, default=True
+        Plot the total concentration in addition to individual species. Can
+        either be True or a list containing 'dna', 'rna', or 'protein'.
+    trace_offset : float or list of float, default=0
+        Value to use in offseting traces, to avoid overlap.  If a list is
+        specified, gives offsets for DNA, RNA, protein, resources.
+    resource_labels : list of str, optional
+        Names of resources.  Defaults to ['metabolite_AAs', 'metabolite_NTPs',
+        'metabolite_ATP'].
     """
-    if not isinstance(genelist, (list, tuple)):
-        genelist = [genelist]
-    min = 60
 
-    timepts = results['time'] / min
-    for gene in genelist:
+    if not isinstance(gene_list, (list, tuple)):
+        gene_list = [gene_list]
+
+    if not isinstance(trace_offset, (list, tuple)):
+        trace_offset = [trace_offset] * 4
+    if not isinstance(concentration_units, (list, tuple)):
+        concentration_label = [concentration_label] * 4
+    if not isinstance(concentration_label, (list, tuple)):
+        concentration_label = [concentration_label] * 4
+
+    timepts = results['time'] / time_units
+    base_offset = 0
+    for gene in gene_list:
         # DNA
         plt.subplot(2, 2, 1)
         dna_species = gene.dna
         dna_species_list = crn.get_all_species_containing(dna_species)
         if len(dna_species_list) > 1:
             dna_total = np.zeros(results['time'].size)
+            offset = base_offset
             for species in dna_species_list:
                 plt.plot(
                     timepts,
-                    results[str(species)],
+                    results[str(species)] / concentration_units[0] + offset,
                     label=species.pretty_print(show_material=False),
                 )
                 dna_total += results[str(species)]
-            plt.plot(
-                timepts,
-                dna_total,
-                label=f"Total {dna_species.pretty_print()}",
-            )
+                offset += trace_offset[0]
+            if plot_total is True or 'dna' in plot_total:
+                plt.plot(
+                    timepts,
+                    dna_total / concentration_units[0],
+                    label=f"Total {dna_species.pretty_print()}",
+                )
         else:
             plt.plot(
                 timepts,
-                results[str(gene.dna)],
+                results[str(gene.dna)] / concentration_units[0],
                 label=dna_species.pretty_print(),
             )
-        plt.title("DNA")
-        plt.legend(fontsize='x-small')
-        plt.ylabel("Concentration [uM]")
+        plt.title("DNA", fontsize=title_fontsize)
+        plt.ylabel(f"Concentration [{concentration_label[0]}]")
+        plt.legend(fontsize=legend_fontsize)
 
         # RNA
         plt.subplot(2, 2, 2)
@@ -1455,26 +1542,30 @@ def plot_gene_expression_data(
         rna_species_list = crn.get_all_species_containing(rna_species)
         if len(rna_species_list) > 1:
             rna_total = np.zeros(results['time'].size)
+            offset = base_offset
             for species in rna_species_list:
                 plt.plot(
                     timepts,
-                    results[str(species)],
+                    results[str(species)] / concentration_units[1] + offset,
                     label=species.pretty_print(show_material=False),
                 )
                 rna_total += results[str(species)]
-            plt.plot(
-                timepts,
-                rna_total,
-                label=f"Total {rna_species.pretty_print()}",
-            )
+                offset += trace_offset[1]
+            if plot_total is True or 'rna' in plot_total:
+                plt.plot(
+                    timepts,
+                    rna_total / concentration_units[1],
+                    label=f"Total {rna_species.pretty_print()}",
+                )
         else:
             plt.plot(
                 timepts,
                 results[str(gene.transcript)],
                 label=rna_species.pretty_print(),
             )
-        plt.title("RNA")
-        plt.legend(fontsize='x-small')
+        plt.title("RNA", fontsize=title_fontsize)
+        plt.ylabel(f"Concentration [{concentration_label[1]}]")
+        plt.legend(fontsize=legend_fontsize)
 
         # Protein
         plt.subplot(2, 2, 3)
@@ -1482,35 +1573,46 @@ def plot_gene_expression_data(
         protein_species_list = crn.get_all_species_containing(protein_species)
         if len(protein_species_list) > 1:
             protein_total = np.zeros(results['time'].size)
+            offset = base_offset
             for species in protein_species_list:
                 plt.plot(
                     timepts,
-                    results[str(species)],
+                    results[str(species)] / concentration_units[2] + offset,
                     label=species.pretty_print(show_material=False),
                 )
                 protein_total += results[str(species)]
-            plt.plot(
-                timepts,
-                protein_total,
-                label=f"Total {protein_species.pretty_print()}",
-            )
+                offset += trace_offset[2]
+            if plot_total is True or 'protein' in plot_total:
+                plt.plot(
+                    timepts,
+                    protein_total / concentration_units[2],
+                    label=f"Total {protein_species.pretty_print()}",
+                )
         else:
             plt.plot(
                 timepts,
-                results[str(protein_species)],
+                results[str(protein_species)] / concentration_units[2],
                 label=protein_species.pretty_print(),
             )
-        plt.title("Protein")
-        plt.legend(fontsize='x-small')
-        plt.ylabel("Concentration [uM]")
-        plt.xlabel("Time [min]")
+        plt.title("Protein", fontsize=title_fontsize)
+        plt.xlabel(f"Time [time_label]")
+        plt.ylabel(f"Concentration [{concentration_label[2]}]")
+        plt.legend(fontsize=legend_fontsize)
 
     plt.subplot(2, 2, 4)
-    plt.plot(timepts, results['metabolite_AAs'], label='AAs')
-    plt.plot(timepts, results['metabolite_NTPs'], label='NTPs')
-    plt.plot(timepts, results['metabolite_ATP'], label='ATP')
-    plt.title("Resources")
-    plt.legend(fontsize='x-small')
-    plt.xlabel("Time [min]")
+    offset = 0
+    for name, label in zip(resource_labels, ['AAs', 'NTPs', 'ATP']):
+        plt.plot(
+            timepts,
+            results[name] / concentration_units[3] + offset,
+            label=label,
+        )
+        offset += trace_offset[3]
 
+    plt.title("Resources", fontsize=title_fontsize)
+    plt.xlabel(f"Time [time_label]")
+    plt.ylabel(f"Concentration [{concentration_label[3]}]")
+    plt.legend(fontsize=legend_fontsize)
+
+    plt.gcf().align_labels()
     plt.tight_layout()

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1408,7 +1408,12 @@ def plot_all_species_containing(
     for species in species_list:
         if isinstance(species, Component):
             species = species.species
-        species_label = species.pretty_print(show_material=show_material)
+        if isinstance(species, str):
+            # get_all_species_containing matches a string against species
+            # names, so the string is the label
+            species_label = species
+        else:
+            species_label = species.pretty_print(show_material=show_material)
 
         compounds = crn.get_all_species_containing(species)
         if len(compounds) == 0:

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1593,7 +1593,7 @@ def plot_gene_expression_data(
                 label=protein_species.pretty_print(),
             )
         plt.title("Protein", fontsize=title_fontsize)
-        plt.xlabel("Time [time_label]")
+        plt.xlabel(f"Time [{time_label}]")
         plt.ylabel(f"Concentration [{concentration_label[2]}]")
         plt.legend(fontsize=legend_fontsize)
 
@@ -1608,7 +1608,7 @@ def plot_gene_expression_data(
         offset += trace_offset[3]
 
     plt.title("Resources", fontsize=title_fontsize)
-    plt.xlabel("Time [time_label]")
+    plt.xlabel(f"Time [{time_label}]")
     plt.ylabel(f"Concentration [{concentration_label[3]}]")
     plt.legend(fontsize=legend_fontsize)
 

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1478,8 +1478,14 @@ def plot_gene_expression_data(
         Pandas dataframe containing the simulation results.
     crn : ChemicalReactionNetwork
         CRN being simulutated (used to determine species names).
-    gene_list : List of Species or str
-        Genes to be used to determine full list of species to plot.
+    gene_list : list of DNAassembly
+        Genes whose expression should be plotted.  Each entry must have
+        `dna`, `transcript`, and `protein` attributes, as a
+        `~components.DNAassembly` does; a species or a name is not
+        enough, since the three species need not share a name.  All
+        three must appear in the compiled CRN, so a model compiled with
+        one-step gene expression, which produces no RNA, cannot be
+        plotted with this routine.
     time_units : float, default=bcp.units.mins
         Units factor used to plot scale time.
     time_label : str, default='min'

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1368,6 +1368,7 @@ def plot_all_species_containing(
     concentration_label='uM',
     legend_fontsize='small',
     show_material=True,
+    show_complex_material=True,
     plot_total=True,
     trace_offset=0,
 ):
@@ -1389,7 +1390,11 @@ def plot_all_species_containing(
     legend_fontsize : str, default='small'
         Font size to use for the legend.
     show_material : bool, default=True
-        Include the material type in the legend string.
+        Include the material type in the legend string for the species
+        itself and for the total.
+    show_complex_material : bool, default=True
+        Include the material type in the legend string for complexes
+        containing the species.
     plot_total : bool, default=True
         Plot the total concentration in addition to individual species.
     trace_offset : float, default=0
@@ -1415,7 +1420,9 @@ def plot_all_species_containing(
                 plt.plot(
                     timepts,
                     results[str(compound)] / concentration_units + offset,
-                    label=compound.pretty_print(show_material=show_material),
+                    label=compound.pretty_print(
+                        show_material=show_complex_material
+                    ),
                 )
                 species_total += results[str(compound)]
                 offset += trace_offset
@@ -1450,6 +1457,7 @@ def plot_gene_expression_data(
     legend_fontsize='x-small',
     title_fontsize='small',
     show_material=True,
+    show_complex_material=False,
     plot_total=True,
     trace_offset=0,
     resource_labels=['metabolite_AAs', 'metabolite_NTPs', 'metabolite_ATP'],
@@ -1480,7 +1488,12 @@ def plot_gene_expression_data(
     title_fontsize : str, default='small'
         Font size to use for individual panel titles.
     show_material : bool, default=True
-        Include the material type in the legend string.
+        Include the material type in the legend string for the DNA, RNA,
+        and protein species and for the totals.
+    show_complex_material : bool, default=False
+        Include the material type in the legend string for complexes
+        containing those species.  Off by default since the expanded
+        names are too long for the panel legends.
     plot_total : bool or list, default=True
         Plot the total concentration in addition to individual species. Can
         either be True or a list containing 'dna', 'rna', or 'protein'.
@@ -1507,6 +1520,7 @@ def plot_gene_expression_data(
         # DNA
         plt.subplot(2, 2, 1)
         dna_species = gene.dna
+        dna_label = dna_species.pretty_print(show_material=show_material)
         dna_species_list = crn.get_all_species_containing(dna_species)
         if len(dna_species_list) > 1:
             dna_total = np.zeros(results['time'].size)
@@ -1515,7 +1529,9 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     results[str(species)] / concentration_units[0] + offset,
-                    label=species.pretty_print(show_material=False),
+                    label=species.pretty_print(
+                        show_material=show_complex_material
+                    ),
                 )
                 dna_total += results[str(species)]
                 offset += trace_offset[0]
@@ -1523,13 +1539,13 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     dna_total / concentration_units[0],
-                    label=f"Total {dna_species.pretty_print()}",
+                    label=f"Total {dna_label}",
                 )
         else:
             plt.plot(
                 timepts,
                 results[str(gene.dna)] / concentration_units[0],
-                label=dna_species.pretty_print(),
+                label=dna_label,
             )
         plt.title("DNA", fontsize=title_fontsize)
         plt.ylabel(f"Concentration [{concentration_label[0]}]")
@@ -1538,6 +1554,7 @@ def plot_gene_expression_data(
         # RNA
         plt.subplot(2, 2, 2)
         rna_species = gene.transcript
+        rna_label = rna_species.pretty_print(show_material=show_material)
         rna_species_list = crn.get_all_species_containing(rna_species)
         if len(rna_species_list) > 1:
             rna_total = np.zeros(results['time'].size)
@@ -1546,7 +1563,9 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     results[str(species)] / concentration_units[1] + offset,
-                    label=species.pretty_print(show_material=False),
+                    label=species.pretty_print(
+                        show_material=show_complex_material
+                    ),
                 )
                 rna_total += results[str(species)]
                 offset += trace_offset[1]
@@ -1554,13 +1573,13 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     rna_total / concentration_units[1],
-                    label=f"Total {rna_species.pretty_print()}",
+                    label=f"Total {rna_label}",
                 )
         else:
             plt.plot(
                 timepts,
                 results[str(gene.transcript)],
-                label=rna_species.pretty_print(),
+                label=rna_label,
             )
         plt.title("RNA", fontsize=title_fontsize)
         plt.ylabel(f"Concentration [{concentration_label[1]}]")
@@ -1569,6 +1588,9 @@ def plot_gene_expression_data(
         # Protein
         plt.subplot(2, 2, 3)
         protein_species = gene.protein
+        protein_label = protein_species.pretty_print(
+            show_material=show_material
+        )
         protein_species_list = crn.get_all_species_containing(protein_species)
         if len(protein_species_list) > 1:
             protein_total = np.zeros(results['time'].size)
@@ -1577,7 +1599,9 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     results[str(species)] / concentration_units[2] + offset,
-                    label=species.pretty_print(show_material=False),
+                    label=species.pretty_print(
+                        show_material=show_complex_material
+                    ),
                 )
                 protein_total += results[str(species)]
                 offset += trace_offset[2]
@@ -1585,13 +1609,13 @@ def plot_gene_expression_data(
                 plt.plot(
                     timepts,
                     protein_total / concentration_units[2],
-                    label=f"Total {protein_species.pretty_print()}",
+                    label=f"Total {protein_label}",
                 )
         else:
             plt.plot(
                 timepts,
                 results[str(protein_species)] / concentration_units[2],
-                label=protein_species.pretty_print(),
+                label=protein_label,
             )
         plt.title("Protein", fontsize=title_fontsize)
         plt.xlabel(f"Time [{time_label}]")

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1478,14 +1478,14 @@ def plot_gene_expression_data(
         Pandas dataframe containing the simulation results.
     crn : ChemicalReactionNetwork
         CRN being simulutated (used to determine species names).
-    gene_list : list of DNAassembly
-        Genes whose expression should be plotted.  Each entry must have
-        `dna`, `transcript`, and `protein` attributes, as a
+    gene_list : DNAassembly or list of DNAassembly
+        Gene, or genes, whose expression should be plotted.  Each entry
+        must have `dna`, `transcript`, and `protein` attributes, as a
         `~components.DNAassembly` does; a species or a name is not
-        enough, since the three species need not share a name.  All
-        three must appear in the compiled CRN, so a model compiled with
-        one-step gene expression, which produces no RNA, cannot be
-        plotted with this routine.
+        enough, since the three species need not share a name.  A panel
+        is left empty if the species it plots is not in the CRN, as the
+        RNA panel is for a model compiled with one-step gene
+        expression.
     time_units : float, default=bcp.units.mins
         Units factor used to plot scale time.
     time_label : str, default='min'
@@ -1552,7 +1552,7 @@ def plot_gene_expression_data(
                     dna_total / concentration_units[0],
                     label=f"Total {dna_label}",
                 )
-        else:
+        elif len(dna_species_list) == 1:
             plt.plot(
                 timepts,
                 results[str(gene.dna)] / concentration_units[0],
@@ -1560,7 +1560,8 @@ def plot_gene_expression_data(
             )
         plt.title("DNA", fontsize=title_fontsize)
         plt.ylabel(f"Concentration [{concentration_label[0]}]")
-        plt.legend(fontsize=legend_fontsize)
+        if dna_species_list:
+            plt.legend(fontsize=legend_fontsize)
 
         # RNA
         plt.subplot(2, 2, 2)
@@ -1586,15 +1587,16 @@ def plot_gene_expression_data(
                     rna_total / concentration_units[1],
                     label=f"Total {rna_label}",
                 )
-        else:
+        elif len(rna_species_list) == 1:
             plt.plot(
                 timepts,
-                results[str(gene.transcript)],
+                results[str(gene.transcript)] / concentration_units[1],
                 label=rna_label,
             )
         plt.title("RNA", fontsize=title_fontsize)
         plt.ylabel(f"Concentration [{concentration_label[1]}]")
-        plt.legend(fontsize=legend_fontsize)
+        if rna_species_list:
+            plt.legend(fontsize=legend_fontsize)
 
         # Protein
         plt.subplot(2, 2, 3)
@@ -1622,7 +1624,7 @@ def plot_gene_expression_data(
                     protein_total / concentration_units[2],
                     label=f"Total {protein_label}",
                 )
-        else:
+        elif len(protein_species_list) == 1:
             plt.plot(
                 timepts,
                 results[str(protein_species)] / concentration_units[2],
@@ -1631,22 +1633,29 @@ def plot_gene_expression_data(
         plt.title("Protein", fontsize=title_fontsize)
         plt.xlabel(f"Time [{time_label}]")
         plt.ylabel(f"Concentration [{concentration_label[2]}]")
-        plt.legend(fontsize=legend_fontsize)
+        if protein_species_list:
+            plt.legend(fontsize=legend_fontsize)
 
     plt.subplot(2, 2, 4)
     offset = 0
+    resources_plotted = False
     for name, label in zip(resource_labels, ['AAs', 'NTPs', 'ATP']):
+        # a mixture need not have the resources being looked for
+        if name not in results:
+            continue
         plt.plot(
             timepts,
             results[name] / concentration_units[3] + offset,
             label=label,
         )
         offset += trace_offset[3]
+        resources_plotted = True
 
     plt.title("Resources", fontsize=title_fontsize)
     plt.xlabel(f"Time [{time_label}]")
     plt.ylabel(f"Concentration [{concentration_label[3]}]")
-    plt.legend(fontsize=legend_fontsize)
+    if resources_plotted:
+        plt.legend(fontsize=legend_fontsize)
 
     plt.gcf().align_labels()
     plt.tight_layout()

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -1403,6 +1403,7 @@ def plot_all_species_containing(
     for species in species_list:
         if isinstance(species, Component):
             species = species.species
+        species_label = species.pretty_print(show_material=show_material)
 
         compounds = crn.get_all_species_containing(species)
         if len(compounds) == 0:
@@ -1422,14 +1423,14 @@ def plot_all_species_containing(
                 plt.plot(
                     timepts,
                     species_total / concentration_units,
-                    label=f"Total {species.pretty_print()}",
+                    label=f"Total {species_label}",
                 )
                 offset += trace_offset
         else:
             plt.plot(
                 timepts,
                 results[str(compounds[0])] / concentration_units,
-                label=species.pretty_print(),
+                label=species_label,
             )
             offset += trace_offset
 

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -14,6 +14,8 @@ import random
 import statistics
 from warnings import warn
 
+import numpy as np
+
 from ..components.basic import DNA, RNA, Protein
 from ..components.dna.cds import CDS
 from ..components.dna.construct import Construct
@@ -21,9 +23,11 @@ from ..components.dna.misc import IntegraseSite, Operator, Origin, UserDefined
 from ..components.dna.promoter import Promoter
 from ..components.dna.rbs import RBS
 from ..components.dna.terminator import Terminator
+from ..core.component import Component
 from ..core.polymer import OrderedPolymer
 from ..core.propensities import MassAction
 from ..core.species import ComplexSpecies, Species
+from ..utils.units import mins
 from . import member_dictionary_search
 
 HAVE_MATPLOTLIB = False
@@ -1352,3 +1356,161 @@ def render_network_bokeh(
             raise ValueError("To export you must supply export_name keyword.")
         export_svgs(plot, filename=export_name + '.svg')
     return plot
+
+
+def plot_all_containing(
+    results,
+    crn,
+    species_list,
+    time_units=mins,
+    legend_fontsize='small',
+    show_material=True,
+):
+    if not isinstance(species_list, (list, tuple)):
+        species_list = [species_list]
+
+    timepts = results['time'] / time_units
+    for species in species_list:
+        if isinstance(species, Component):
+            species = species.species
+
+        compounds = crn.get_all_species_containing(species)
+        if len(compounds) > 1:
+            species_total = np.zeros(results['time'].size)
+            for compound in compounds:
+                plt.plot(
+                    timepts,
+                    results[str(compound)],
+                    label=compound.pretty_print(show_material=show_material),
+                )
+                species_total += results[str(compound)]
+            plt.plot(
+                timepts,
+                species_total,
+                label=f"Total {species.pretty_print()}",
+            )
+        else:
+            plt.plot(
+                timepts,
+                results[str(compounds[0])],
+                label=species.pretty_print(),
+            )
+        plt.legend(fontsize=legend_fontsize)
+        plt.ylabel("Concentration [uM]")
+
+
+def plot_gene_expression_data(
+    results,
+    crn,
+    genelist,
+    plot_totals=None,
+):
+    """Plot DNA, RNA, and protein concentrations for a list of genes.
+
+    Generate a plot showing the concentrations of all species associated with
+    expression of a gene, including complex containing the species.
+
+    Parameters
+    ----------
+    results :
+
+    """
+    if not isinstance(genelist, (list, tuple)):
+        genelist = [genelist]
+    min = 60
+
+    timepts = results['time'] / min
+    for gene in genelist:
+        # DNA
+        plt.subplot(2, 2, 1)
+        dna_species = gene.dna
+        dna_species_list = crn.get_all_species_containing(dna_species)
+        if len(dna_species_list) > 1:
+            dna_total = np.zeros(results['time'].size)
+            for species in dna_species_list:
+                plt.plot(
+                    timepts,
+                    results[str(species)],
+                    label=species.pretty_print(show_material=False),
+                )
+                dna_total += results[str(species)]
+            plt.plot(
+                timepts,
+                dna_total,
+                label=f"Total {dna_species.pretty_print()}",
+            )
+        else:
+            plt.plot(
+                timepts,
+                results[str(gene.dna)],
+                label=dna_species.pretty_print(),
+            )
+        plt.title("DNA")
+        plt.legend(fontsize='x-small')
+        plt.ylabel("Concentration [uM]")
+
+        # RNA
+        plt.subplot(2, 2, 2)
+        rna_species = gene.transcript
+        rna_species_list = crn.get_all_species_containing(rna_species)
+        if len(rna_species_list) > 1:
+            rna_total = np.zeros(results['time'].size)
+            for species in rna_species_list:
+                plt.plot(
+                    timepts,
+                    results[str(species)],
+                    label=species.pretty_print(show_material=False),
+                )
+                rna_total += results[str(species)]
+            plt.plot(
+                timepts,
+                rna_total,
+                label=f"Total {rna_species.pretty_print()}",
+            )
+        else:
+            plt.plot(
+                timepts,
+                results[str(gene.transcript)],
+                label=rna_species.pretty_print(),
+            )
+        plt.title("RNA")
+        plt.legend(fontsize='x-small')
+
+        # Protein
+        plt.subplot(2, 2, 3)
+        protein_species = gene.protein
+        protein_species_list = crn.get_all_species_containing(protein_species)
+        if len(protein_species_list) > 1:
+            protein_total = np.zeros(results['time'].size)
+            for species in protein_species_list:
+                plt.plot(
+                    timepts,
+                    results[str(species)],
+                    label=species.pretty_print(show_material=False),
+                )
+                protein_total += results[str(species)]
+            plt.plot(
+                timepts,
+                protein_total,
+                label=f"Total {protein_species.pretty_print()}",
+            )
+        else:
+            plt.plot(
+                timepts,
+                results[str(protein_species)],
+                label=protein_species.pretty_print(),
+            )
+        plt.title("Protein")
+        plt.legend(fontsize='x-small')
+        plt.ylabel("Concentration [uM]")
+        plt.xlabel("Time [min]")
+
+    plt.subplot(2, 2, 4)
+    plt.plot(timepts, results['metabolite_AAs'], label='AAs')
+    plt.plot(timepts, results['metabolite_NTPs'], label='NTPs')
+    plt.plot(timepts, results['metabolite_ATP'], label='ATP')
+    plt.title("Resources")
+    plt.legend(fontsize='x-small')
+    plt.xlabel("Time [min]")
+
+    plt.tight_layout()

--- a/biocrnpyler/utils/plotting.py
+++ b/biocrnpyler/utils/plotting.py
@@ -27,7 +27,7 @@ from ..core.component import Component
 from ..core.polymer import OrderedPolymer
 from ..core.propensities import MassAction
 from ..core.species import ComplexSpecies, Species
-from ..utils.units import mins, nM, uM, mM
+from ..utils.units import mins, mM, nM, uM
 from . import member_dictionary_search
 
 HAVE_MATPLOTLIB = False
@@ -1395,7 +1395,6 @@ def plot_all_species_containing(
     trace_offset : float, default=0
         Value to use in offseting traces, to avoid overlap.
     """
-
     if not isinstance(species_list, (list, tuple)):
         species_list = [species_list]
 
@@ -1491,7 +1490,6 @@ def plot_gene_expression_data(
         Names of resources.  Defaults to ['metabolite_AAs', 'metabolite_NTPs',
         'metabolite_ATP'].
     """
-
     if not isinstance(gene_list, (list, tuple)):
         gene_list = [gene_list]
 
@@ -1595,7 +1593,7 @@ def plot_gene_expression_data(
                 label=protein_species.pretty_print(),
             )
         plt.title("Protein", fontsize=title_fontsize)
-        plt.xlabel(f"Time [time_label]")
+        plt.xlabel("Time [time_label]")
         plt.ylabel(f"Concentration [{concentration_label[2]}]")
         plt.legend(fontsize=legend_fontsize)
 
@@ -1610,7 +1608,7 @@ def plot_gene_expression_data(
         offset += trace_offset[3]
 
     plt.title("Resources", fontsize=title_fontsize)
-    plt.xlabel(f"Time [time_label]")
+    plt.xlabel("Time [time_label]")
     plt.ylabel(f"Concentration [{concentration_label[3]}]")
     plt.legend(fontsize=legend_fontsize)
 

--- a/docs/_autogen_mixtures.rst
+++ b/docs/_autogen_mixtures.rst
@@ -49,5 +49,6 @@ Pure
    :nosignatures:
    :recursive:
 
+    PURE
     BasicPURE
 

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -136,4 +136,4 @@ generates its species and reactions during compilation. For example::
             pass
 
 By defining custom components, users can encode arbitrary logic or kinetic
-forms while still integrating seamlessly with mixtures and Mechanisms.
+forms while still integrating seamlessly with mixtures and mechanisms.

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -256,3 +256,78 @@ dynamics, or fit parameters.
 Together, these tools make it easy to go from a high-level BioCRNpyler
 design to a fully specified, exportable, and simulatable chemical
 reaction network model.
+
+
+Plotting Simulation Results
+---------------------------
+
+Simulation results can be plotted directly with matplotlib, as above, but
+a compiled CRN often contains more species than you wrote down.  A species
+that binds to anything else appears both on its own and inside every
+complex that contains it, and those complexes have long generated names.
+BioCRNpyler provides two plotting routines that take the CRN itself as an
+argument and work out the relevant species for you.
+
+`~utils.plotting.plot_all_species_containing` plots every species that
+contains a given species, including complexes, along with the total::
+
+    bcp.plot_all_species_containing(results, crn, ribosome)
+
+This is the routine to use when you want to know where a species has gone.
+A ribosome in a PURE model, for example, is distributed between its free
+form and the translation complexes it participates in; plotting all of
+them together shows the free pool being drawn down while the total stays
+constant.  Passing a list plots several species on the same axes, and a
+`~core.Component` may be given in place of a `~core.Species`.
+
+`~utils.plotting.plot_gene_expression_data` summarizes the expression of
+one or more genes as a set of four panels -- DNA, RNA, protein, and
+resources::
+
+    bcp.plot_gene_expression_data(results, crn, dna_assembly)
+
+Each panel shows the individual species, any complexes containing them,
+and the total.
+
+Both routines let you control how much of each species name appears in
+the legend.  `show_material` governs the species itself and the total,
+while `show_complex_material` governs the complexes::
+
+    bcp.plot_all_species_containing(
+        results, crn, ribosome,
+        show_material=False, show_complex_material=False
+    )
+
+The distinction matters because expanded complex names grow quickly.  A
+ribosome bound to a transcript together with amino acids and ATP is
+rendered as::
+
+    complex[metabolite[AAs]:4x_metabolite[ATP]:protein[Ribo]:rna[GFP]]
+
+which will overwhelm a legend.  Turning `show_complex_material` off
+abbreviates it to ``[AAs:4x_ATP:Ribo:GFP]``.  It is off by default in
+`~utils.plotting.plot_gene_expression_data`, whose four panels leave
+little room, and on by default in
+`~utils.plotting.plot_all_species_containing`.
+
+`~utils.plotting.plot_all_species_containing` draws on the current axes
+and sets the axis labels and legend, so it composes with the usual
+matplotlib calls for figures, subplots, titles, and limits.
+`~utils.plotting.plot_gene_expression_data` lays out its own two by two
+grid of subplots and so takes over the current figure.
+
+Units are handled through the `time_units` and
+`concentration_units` arguments.  Time defaults to minutes in both
+routines.  Concentration defaults to micromolar in
+`~utils.plotting.plot_all_species_containing`, while
+`~utils.plotting.plot_gene_expression_data` takes a list giving the
+units for the DNA, RNA, protein, and resource panels separately,
+defaulting to nanomolar, micromolar, micromolar, and millimolar::
+
+    bcp.plot_all_species_containing(
+        results, crn, ribosome,
+        time_units=hrs, time_label='hr'
+    )
+
+A worked example using both routines is given in
+``examples/gfp_expression.py``.

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -153,3 +153,21 @@ The following subsections provide a list of all mixtures currently
 available in the BioCRNpyler package.
 
 .. include:: _autogen_mixtures.rst
+
+
+Plotting
+========
+
+Prefix: `biocrnpyler.utils.plotting`
+
+.. automodule:: biocrnpyler.utils.plotting
+
+The following functions generate plots of simulation results, using the
+compiled CRN to determine which species to include.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   plot_all_species_containing
+   plot_gene_expression_data

--- a/docs/mixtures.rst
+++ b/docs/mixtures.rst
@@ -369,6 +369,62 @@ This mixture enables modeling of regulatory control, enzyme-mediated
 kinetics, and system-wide dilution, providing a richer, more detailed
 representation of gene expression in cells.
 
+PURE Mixtures
+~~~~~~~~~~~~~
+
+The PURE (Protein synthesis Using Recombinant Elements) system is a
+reconstituted cell-free system, assembled from purified components rather
+than from a cell extract.  Because the composition is known, PURE models
+can account explicitly for the machinery and the consumable resources that
+limit expression.
+
+A single mixture, `~mixtures.PURE`, covers the whole range of PURE models.
+Rather than choosing between separate classes, you select the level of
+detail with three switches::
+
+    pure_mixture = PURE(
+        name='pure',
+        components=[dna_part],
+        include_machinery=True,
+        include_resources=True,
+        include_fuel=True,
+    )
+
+The switches are nested: each one requires the ones above it.
+
++---------------------+------------------------------------------------+
+| Argument            | Effect when True                               |
++=====================+================================================+
+| include_machinery   | Adds RNA polymerase and ribosome, so that      |
+|                     | expression competes for a finite pool of       |
+|                     | machinery                                      |
++---------------------+------------------------------------------------+
+| include_resources   | Adds NTP and amino acid consumption, so that   |
+|                     | transcription and translation draw down a      |
+|                     | finite supply of building blocks               |
++---------------------+------------------------------------------------+
+| include_fuel        | Adds the fuel species (ATP) and energy         |
+|                     | utilization, so that expression halts when the |
+|                     | system runs out of energy                      |
++---------------------+------------------------------------------------+
+
+Turning all three off gives a minimal model in which expression proceeds
+without competition or depletion.  Turning them on one at a time is a
+convenient way to see which limitation dominates in a given design: with
+machinery alone, two genes compete for ribosomes; adding resources makes
+expression taper as amino acids are consumed; adding fuel makes it stop
+altogether once ATP is exhausted.
+
+The species names can be changed if the defaults clash with the rest of
+your model::
+
+    pure_mixture = PURE(
+        name='pure', components=[dna_part], ribosome='Ribosome'
+    )
+
+`~mixtures.BasicPURE` remains available and is equivalent to
+`~mixtures.PURE` with all three switches set to True.
+
 
 Custom Mixtures
 ----------------

--- a/docs/mixtures.rst
+++ b/docs/mixtures.rst
@@ -422,8 +422,9 @@ your model::
         name='pure', components=[dna_part], ribosome='Ribosome'
     )
 
-`~mixtures.BasicPURE` remains available and is equivalent to
-`~mixtures.PURE` with all three switches set to True.
+`~mixtures.BasicPURE` is equivalent to `~mixtures.PURE` with all three
+switches set to True.  It is deprecated and raises a warning when
+constructed; use `~mixtures.PURE` directly in new models.
 
 
 Custom Mixtures

--- a/docs/mixtures.rst
+++ b/docs/mixtures.rst
@@ -387,7 +387,7 @@ detail with three switches::
         components=[dna_part],
         include_machinery=True,
         include_resources=True,
-        include_fuel=True,
+        include_energy=True,
     )
 
 The switches are nested: each one requires the ones above it.
@@ -403,16 +403,16 @@ The switches are nested: each one requires the ones above it.
 |                     | transcription and translation draw down a      |
 |                     | finite supply of building blocks               |
 +---------------------+------------------------------------------------+
-| include_fuel        | Adds the fuel species (ATP) and energy         |
-|                     | utilization, so that expression halts when the |
-|                     | system runs out of energy                      |
+| include_energy      | Adds the energy carriers (ATP and ADP) and     |
+|                     | their regeneration from fuel, so that          |
+|                     | expression halts when energy runs out          |
 +---------------------+------------------------------------------------+
 
 Turning all three off gives a minimal model in which expression proceeds
 without competition or depletion.  Turning them on one at a time is a
 convenient way to see which limitation dominates in a given design: with
 machinery alone, two genes compete for ribosomes; adding resources makes
-expression taper as amino acids are consumed; adding fuel makes it stop
+expression taper as amino acids are consumed; adding energy makes it stop
 altogether once ATP is exhausted.
 
 The species names can be changed if the defaults clash with the rest of

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -235,7 +235,7 @@ pure_mixture = bcp.PURE(
     components=[gfp_dna],
     include_machinery=True,
     include_resources=True,
-    include_fuel=True,
+    include_energy=True,
 )
 pure_crn = pure_mixture.compile_crn()
 pure_res = pure_crn.simulate_with_bioscrape_via_sbml(
@@ -260,7 +260,7 @@ pure_timepts = np.linspace(0, 180 * min)
 
 simple_mixture = bcp.PURE(
     name='simple', components=[gfp_dna, cfp_dna],
-    include_machinery=False, include_resources=False, include_fuel=False)
+    include_machinery=False, include_resources=False, include_energy=False)
 simple_crn = simple_mixture.compile_crn()
 simple_res = simple_crn.simulate_with_bioscrape_via_sbml(
     pure_timepts, initial_condition_dict=cfp_initial_conditions
@@ -268,7 +268,7 @@ simple_res = simple_crn.simulate_with_bioscrape_via_sbml(
 
 machinery_mixture = bcp.PURE(
     name='machinery', components=[gfp_dna, cfp_dna],
-    include_machinery=True, include_resources=False, include_fuel=False)
+    include_machinery=True, include_resources=False, include_energy=False)
 machinery_crn = machinery_mixture.compile_crn()
 machinery_res = machinery_crn.simulate_with_bioscrape_via_sbml(
     pure_timepts, initial_condition_dict=cfp_initial_conditions
@@ -276,7 +276,7 @@ machinery_res = machinery_crn.simulate_with_bioscrape_via_sbml(
 
 resource_mixture = bcp.PURE(
     name='resources', components=[gfp_dna, cfp_dna],
-    include_machinery=True, include_resources=True, include_fuel=False)
+    include_machinery=True, include_resources=True, include_energy=False)
 resource_crn = resource_mixture.compile_crn()
 resource_res = resource_crn.simulate_with_bioscrape_via_sbml(
     pure_timepts, initial_condition_dict=cfp_initial_conditions
@@ -284,7 +284,7 @@ resource_res = resource_crn.simulate_with_bioscrape_via_sbml(
 
 energy_mixture = bcp.PURE(
     name='energy', components=[gfp_dna, cfp_dna],
-    include_machinery=True, include_resources=True, include_fuel=True)
+    include_machinery=True, include_resources=True, include_energy=True)
 energy_crn = energy_mixture.compile_crn()
 energy_res = energy_crn.simulate_with_bioscrape_via_sbml(
     pure_timepts, initial_condition_dict=cfp_initial_conditions
@@ -292,7 +292,7 @@ energy_res = energy_crn.simulate_with_bioscrape_via_sbml(
 
 energy_mixture_gfp = bcp.PURE(
     name='energy', components=[gfp_dna],
-    include_machinery=True, include_resources=True, include_fuel=True)
+    include_machinery=True, include_resources=True, include_energy=True)
 energy_crn_gfp = energy_mixture_gfp.compile_crn()
 energy_res_gfp = energy_crn_gfp.simulate_with_bioscrape_via_sbml(
     pure_timepts, initial_condition_dict=initial_conditions
@@ -347,7 +347,7 @@ repressed_mixture = bcp.PURE(
     components=[dna_GFP_repressed, TetR_inactive],
     include_machinery=True,
     include_resources=True,
-    include_fuel=True,
+    include_energy=True,
 )
 repressed_crn = repressed_mixture.compile_crn()
 
@@ -370,7 +370,7 @@ regulated_mixture = bcp.PURE(
     components=[dna_GFP_regulated, TetR_inactive],
     include_machinery=True,
     include_resources=True,
-    include_fuel=True,
+    include_energy=True,
     parameters=regulated_parameters,
 )
 regulated_crn = regulated_mixture.compile_crn()

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -18,7 +18,7 @@ gfp_dna = bcp.DNAassembly(
 )
 
 # Simulation parmaters
-initial_conditions_dict = {'dna_gfp': 1 * nM}
+initial_conditions = {'dna_gfp': 1 * nM}
 timepts = np.linspace(0, 6 * hrs, 1000)
 
 #
@@ -30,7 +30,7 @@ expr_mixture = bcp.ExpressionExtract(
 )
 expr_crn = expr_mixture.compile_crn()
 expr_res = expr_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions_dict
+    timepts, initial_condition_dict=initial_conditions
 )
 
 #
@@ -42,7 +42,7 @@ simple_mixture = bcp.SimpleTxTlExtract(
 )
 simple_crn = simple_mixture.compile_crn()
 simple_res = simple_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions_dict
+    timepts, initial_condition_dict=initial_conditions
 )
 
 #
@@ -54,7 +54,7 @@ regular_mixture = bcp.TxTlExtract(
 )
 regular_crn = regular_mixture.compile_crn()
 regular_res = regular_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions_dict
+    timepts, initial_condition_dict=initial_conditions
 )
 
 #
@@ -66,7 +66,7 @@ energy_mixture = bcp.EnergyTxTlExtract(
 )
 energy_crn = energy_mixture.compile_crn()
 energy_res = energy_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions_dict
+    timepts, initial_condition_dict=initial_conditions
 )
 
 #
@@ -144,7 +144,7 @@ plt.legend()
 plt.figure(4)
 plt.clf()
 
-cfp_initial_conditions = initial_conditions_dict
+cfp_initial_conditions = initial_conditions.copy()
 cfp_initial_conditions['dna_cfp'] = 1 * nM
 
 # Add some additional DNA that will utilize resources
@@ -236,7 +236,7 @@ pure_mixture = bcp.BasicPURE(
 )
 pure_crn = pure_mixture.compile_crn()
 pure_res = pure_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions_dict
+    timepts, initial_condition_dict=initial_conditions
 )
 
 plt.figure(5)
@@ -245,6 +245,79 @@ plt.plot(timepts / min, energy_res['protein_GFP'] / uM, label='GFP, TX-TL')
 plt.plot(timepts / min, pure_res['protein_GFP'] / uM, label='GFP, PURE')
 
 plt.title("Mixture Comparisions - TX-TL vs PURE")
+plt.xlabel("Time [min]")
+plt.ylabel("Concentration [uM]")
+plt.legend()
+
+#
+# PURE mixtures
+#
+
+simple_mixture = bcp.PURE(
+    name='simple', components=[gfp_dna, cfp_dna],
+    include_machinery=False, include_resources=False, include_fuel=False)
+simple_crn = simple_mixture.compile_crn()
+simple_res = simple_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=cfp_initial_conditions
+)
+
+machinery_mixture = bcp.PURE(
+    name='machinery', components=[gfp_dna, cfp_dna],
+    include_machinery=True, include_resources=False, include_fuel=False)
+machinery_crn = machinery_mixture.compile_crn()
+machinery_res = machinery_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=cfp_initial_conditions
+)
+
+resource_mixture = bcp.PURE(
+    name='resources', components=[gfp_dna, cfp_dna],
+    include_machinery=True, include_resources=True, include_fuel=False)
+resource_crn = resource_mixture.compile_crn()
+resource_res = resource_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=cfp_initial_conditions
+)
+
+energy_mixture = bcp.PURE(
+    name='energy', components=[gfp_dna, cfp_dna],
+    include_machinery=True, include_resources=True, include_fuel=True)
+energy_crn = energy_mixture.compile_crn()
+energy_res = energy_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=cfp_initial_conditions
+)
+
+energy_mixture_gfp = bcp.PURE(
+    name='energy', components=[gfp_dna],
+    include_machinery=True, include_resources=True, include_fuel=True)
+energy_crn_gfp = energy_mixture_gfp.compile_crn()
+energy_res_gfp = energy_crn_gfp.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=initial_conditions
+)
+
+plt.figure(6)
+plt.clf()
+
+plt.plot(
+    timepts / min, simple_res['protein_GFP'] / uM,
+    label='GFP+CFP, simple')
+plt.plot(
+    timepts / min, machinery_res['protein_GFP'] / uM,
+    label='GFP+CFP, machinery')
+plt.plot(
+     timepts / min, resource_res['protein_GFP'] / uM,
+     label='GFP+CFP, resources')
+plt.plot(
+    timepts / min, energy_res['protein_GFP'] / uM,
+    label='GFP+CFP, energy')
+plt.plot(
+    timepts / min, energy_res_gfp['protein_GFP'] / uM,
+    label='GFP only, energy')
+plt.plot(
+    timepts / min, pure_res['protein_GFP'] + 0.1 / uM, '--',
+    label='GFP only + 0.1, basic')
+
+plt.ylim([0, 12])
+
+plt.title("PURE Mixture Comparisions")
 plt.xlabel("Time [min]")
 plt.ylabel("Concentration [uM]")
 plt.legend()

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -454,14 +454,16 @@ ribosome = bcp.Species('Ribo', material_type='protein')
 plt.subplot(1, 2, 1)
 bcp.plot_all_species_containing(
     repressed_res, repressed_crn, ribosome,
-    show_material=False, legend_fontsize='x-small'
+    show_material=False, show_complex_material=False,
+    legend_fontsize='x-small'
 )
 plt.title("Ribosome", fontsize='small')
 
 plt.subplot(1, 2, 2)
 bcp.plot_all_species_containing(
     repressed_res, repressed_crn, [TetR, aTc],
-    show_material=False, legend_fontsize='x-small'
+    show_material=False, show_complex_material=False,
+    legend_fontsize='x-small'
 )
 plt.title("TetR and aTc", fontsize='small')
 

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -437,3 +437,33 @@ bcp.plot_gene_expression_data(
     trace_offset=[0.01, 0.002, 0.1, 0.1])
 plt.suptitle("Gene expression, regulated", fontsize='large')
 plt.tight_layout()
+
+#
+# Species distributed across complexes
+#
+# Show how a species is distributed between its free form and the complexes
+# that contain it.  The ribosome is split between free ribosome and the
+# translation complexes; TetR is sequestered by aTc.
+#
+
+plt.figure(10)
+plt.clf()
+
+ribosome = bcp.Species('Ribo', material_type='protein')
+
+plt.subplot(1, 2, 1)
+bcp.plot_all_species_containing(
+    repressed_res, repressed_crn, ribosome,
+    show_material=False, legend_fontsize='x-small'
+)
+plt.title("Ribosome", fontsize='small')
+
+plt.subplot(1, 2, 2)
+bcp.plot_all_species_containing(
+    repressed_res, repressed_crn, [TetR, aTc],
+    show_material=False, legend_fontsize='x-small'
+)
+plt.title("TetR and aTc", fontsize='small')
+
+plt.suptitle("Species containing a given species", fontsize='large')
+plt.tight_layout()

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -230,9 +230,12 @@ plt.legend()
 # Comparison with PURE
 #
 
-pure_mixture = bcp.BasicPURE(
+pure_mixture = bcp.PURE(
     name='regular',
     components=[gfp_dna],
+    include_machinery=True,
+    include_resources=True,
+    include_fuel=True,
 )
 pure_crn = pure_mixture.compile_crn()
 pure_res = pure_crn.simulate_with_bioscrape_via_sbml(

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -17,7 +17,7 @@ gfp_dna = bcp.DNAassembly(
     name='gfp', promoter='pconst', rbs='rbs_strong', protein='GFP'
 )
 
-# Simulation parmaters
+# Simulation parameters
 initial_conditions = {'dna_gfp': 1 * nM}
 timepts = np.linspace(0, 6 * hrs, 1000)
 
@@ -253,12 +253,14 @@ plt.legend()
 # PURE mixtures
 #
 
+pure_timepts = np.linspace(0, 180 * min)
+
 simple_mixture = bcp.PURE(
     name='simple', components=[gfp_dna, cfp_dna],
     include_machinery=False, include_resources=False, include_fuel=False)
 simple_crn = simple_mixture.compile_crn()
 simple_res = simple_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    pure_timepts, initial_condition_dict=cfp_initial_conditions
 )
 
 machinery_mixture = bcp.PURE(
@@ -266,7 +268,7 @@ machinery_mixture = bcp.PURE(
     include_machinery=True, include_resources=False, include_fuel=False)
 machinery_crn = machinery_mixture.compile_crn()
 machinery_res = machinery_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    pure_timepts, initial_condition_dict=cfp_initial_conditions
 )
 
 resource_mixture = bcp.PURE(
@@ -274,7 +276,7 @@ resource_mixture = bcp.PURE(
     include_machinery=True, include_resources=True, include_fuel=False)
 resource_crn = resource_mixture.compile_crn()
 resource_res = resource_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    pure_timepts, initial_condition_dict=cfp_initial_conditions
 )
 
 energy_mixture = bcp.PURE(
@@ -282,7 +284,7 @@ energy_mixture = bcp.PURE(
     include_machinery=True, include_resources=True, include_fuel=True)
 energy_crn = energy_mixture.compile_crn()
 energy_res = energy_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    pure_timepts, initial_condition_dict=cfp_initial_conditions
 )
 
 energy_mixture_gfp = bcp.PURE(
@@ -290,29 +292,29 @@ energy_mixture_gfp = bcp.PURE(
     include_machinery=True, include_resources=True, include_fuel=True)
 energy_crn_gfp = energy_mixture_gfp.compile_crn()
 energy_res_gfp = energy_crn_gfp.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=initial_conditions
+    pure_timepts, initial_condition_dict=initial_conditions
 )
 
 plt.figure(6)
 plt.clf()
 
 plt.plot(
-    timepts / min, simple_res['protein_GFP'] / uM,
+    pure_timepts / min, simple_res['protein_GFP'] / uM,
     label='GFP+CFP, simple')
 plt.plot(
-    timepts / min, machinery_res['protein_GFP'] / uM,
+    pure_timepts / min, machinery_res['protein_GFP'] / uM,
     label='GFP+CFP, machinery')
 plt.plot(
-     timepts / min, resource_res['protein_GFP'] / uM,
+     pure_timepts / min, resource_res['protein_GFP'] / uM,
      label='GFP+CFP, resources')
 plt.plot(
-    timepts / min, energy_res['protein_GFP'] / uM,
+    pure_timepts / min, energy_res['protein_GFP'] / uM,
     label='GFP+CFP, energy')
 plt.plot(
-    timepts / min, energy_res_gfp['protein_GFP'] / uM,
+    pure_timepts / min, energy_res_gfp['protein_GFP'] / uM,
     label='GFP only, energy')
 plt.plot(
-    timepts / min, pure_res['protein_GFP'] + 0.1 / uM, '--',
+    timepts[0:50] / min, pure_res['protein_GFP'][0:50] + 0.1 / uM, '--',
     label='GFP only + 0.1, basic')
 
 plt.ylim([0, 12])
@@ -321,3 +323,117 @@ plt.title("PURE Mixture Comparisions")
 plt.xlabel("Time [min]")
 plt.ylabel("Concentration [uM]")
 plt.legend()
+
+#
+# Activators and repressors
+#
+
+TetR = bcp.Protein('TetR')
+aTc = bcp.Species('aTc')
+TetR_inactive = bcp.ChemicalComplex(
+    [TetR.species, aTc], mechanisms={'binding': bcp.One_Step_Binding()}
+)
+ptet_repressed = bcp.RepressiblePromoter('ptet', TetR)
+dna_GFP_repressed = bcp.DNAassembly(
+    'GFP', promoter=ptet_repressed, rbs='RBS', protein='GFP', length=714
+)
+
+initial_conditions = {'dna_GFP': 1 * nM, 'protein_TetR': 30 * uM}
+repressed_mixture = bcp.PURE(
+    name='repressed',
+    components=[dna_GFP_repressed, TetR_inactive],
+    include_machinery=True,
+    include_resources=True,
+    include_fuel=True,
+)
+repressed_crn = repressed_mixture.compile_crn()
+
+TetR = bcp.Protein('TetR')
+aTc = bcp.Species('aTc')
+TetR_inactive = bcp.ChemicalComplex(
+    [TetR.species, aTc], mechanisms={'binding': bcp.One_Step_Binding()}
+)
+ptet_regulated = bcp.RegulatedPromoter('ptet', TetR)
+dna_GFP_regulated = bcp.DNAassembly(
+    'GFP', promoter=ptet_regulated, rbs='RBS', protein='GFP'
+)
+regulated_parameters = {
+    ('transcription', 'ptet_leak', 'ktx'): 50,          # unbound
+    ('transcription', 'ptet_TetR', 'ktx'): 0.001,       # bound
+}
+
+regulated_mixture = bcp.PURE(
+    name='regulated',
+    components=[dna_GFP_regulated, TetR_inactive],
+    include_machinery=True,
+    include_resources=True,
+    include_fuel=True,
+    parameters=regulated_parameters,
+)
+regulated_crn = regulated_mixture.compile_crn()
+
+plt.figure(7)
+plt.clf()
+
+offset = -0.01
+TetR_0 = initial_conditions['protein_TetR']
+for aTc_0 in np.linspace(0, 50*uM, 5):
+# aTc_0 = 0
+# for TetR_0 in np.linspace(0, 20*uM, 5):
+    repressed_res = repressed_crn.simulate_with_bioscrape_via_sbml(
+        pure_timepts, initial_condition_dict=initial_conditions
+        | {'aTc': aTc_0} | {'protein_TetR': TetR_0}
+    )
+    lines = plt.plot(
+        pure_timepts / min,
+        repressed_res['protein_GFP'] / uM + offset,
+        label=f"aTc={aTc_0 / uM} uM, TetR={TetR_0 / uM} uM",
+    )
+
+    regulated_res = regulated_crn.simulate_with_bioscrape_via_sbml(
+        pure_timepts, initial_condition_dict=initial_conditions
+        | {'aTc': aTc_0} | {'protein_TetR': TetR_0}
+    )
+    plt.plot(
+        pure_timepts / min,
+        regulated_res['protein_GFP'] / uM + offset,
+        color=lines[0].get_color(),
+        linestyle='--',
+    )
+
+    offset += 0.05
+
+plt.title("Represssed (-) versus Regulated (--)")
+plt.xlabel("Time [min]")
+plt.ylabel("Concentration [uM]")
+plt.legend()
+
+#
+# PURE debugging
+#
+
+repressed_res = repressed_crn.simulate_with_bioscrape_via_sbml(
+    pure_timepts, initial_condition_dict=initial_conditions
+    | {'aTc': 37.5 * uM} | {'protein_TetR': 30 * uM}
+)
+
+plt.figure(8)
+plt.clf()
+bcp.plot_gene_expression_data(
+    repressed_res, repressed_crn, dna_GFP_repressed,
+    trace_offset=[0.01, 0.002, 0.1, 0.1])
+plt.suptitle("Gene expression, repressed", fontsize='large')
+plt.tight_layout()
+
+regulated_res = regulated_crn.simulate_with_bioscrape_via_sbml(
+    pure_timepts, initial_condition_dict=initial_conditions
+    | {'aTc': 37.5 * uM} | {'protein_TetR': 30 * uM}
+)
+
+plt.figure(9)
+plt.clf()
+bcp.plot_gene_expression_data(
+    regulated_res, regulated_crn, dna_GFP_regulated,
+    trace_offset=[0.01, 0.002, 0.1, 0.1])
+plt.suptitle("Gene expression, regulated", fontsize='large')
+plt.tight_layout()


### PR DESCRIPTION
~DRAFT PR.  Putting this out so people can see the changes coming.  The items that were still outstanding are now done:~

- [x] Need to add an example of `plot_all_species_containing`
- [x] May want to update the way attributes passed as a single string are handed (see below)
- [x] Need to add user documentation for PURE and plotting changes

This PR makes a number changes to the way that PURE is implemented:
* There is now a single `PURE` mixture that uses parameters to turn on/off the use of machinery, resources, and energy (`include_machinery`, `include_resources`, `include_energy`).  This means that we don't need separate `SimplePURE`, `EnergyPURE`, etc.  A separate `fuel` argument names the species that regenerates ATP, and setting it to `None` keeps ATP consumption but drops the regeneration pathway.  The old `BasicPURE` mixture is now deprecated: it is `PURE` with all three switches on and `fuel=None`, which is the energy model it had before `PURE` was introduced, and it issues a `DeprecationWarning` when constructed.
* Parameter values have been updated to come from documented sources (mainly SK07 = V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic Tetracycline-Inducible Regulatory Networks: Computer-Aided Design of Dynamic Phenotypes.", BMC Systems Biology 1, no. 1 (2007))
* The unused `ndps` argument has been removed from `PURE`.  It was accepted and documented but never created a species, so `PURE(ndps=...)` silently did nothing; it now raises a `TypeError`.

In addition, some changes that go beyond PURE were also implemented:
* There are now default mechanisms for all standard components.  This means that you can create models without having to explicitly specific the mechanisms, as long as you are OK with the defaults.
* New plotting routines to generate plots containing a given species (`plot_all_species_containing`) or gene expression data (`plot_gene_expression_data`).  How much of each species name appears in the legend is controlled with `show_material`, for the species itself and the totals, and `show_complex_material`, for the complexes containing it.
* Updated use of `attributes` to always pass a list (rather than a string).  This addresses the issue pointed out by @zjuradoq in PR #320.  In addition, an attribute passed as a single string is now treated as one attribute, rather than being split into one attribute per character.
* User documentation for the PURE mixture and the plotting routines has been added to the User Guide, and the plotting routines now appear in the reference manual.
* `Mixture.compile_crn` no longer calls `resetwarnings()`.  It was discarding every warning filter in the process, not just ones set by the package, so filters installed by the caller were dropped the first time a CRN was compiled.  This affects all mixtures, not just PURE.
* Unit tests for `PURE` have been added in `Tests/Unit/test_pure.py`, covering the three switches, the species name arguments, and the `BasicPURE` deprecation.

Sample plot for `plot_gene_expression_data` (from `gfp_expression.py`):
<img width="818" height="617" alt="image" src="https://github.com/user-attachments/assets/a43eb711-9bcd-41d0-ba89-8d73909e3364" />

Sample plot for `plot_all_species_containing` (from `gfp_expression.py`):
<img width="818" height="617" alt="image" src="https://github.com/user-attachments/assets/5f50ebd2-c97d-430c-908b-76226c440b1d" />




