### PR TITLE
AI coding guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+## 5. Behavioral Guidelines
+
+Read docs/develop.rst before writing or editing any code or docstrings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,17 @@ For multi-step tasks, state a brief plan:
 ## 5. Behavioral Guidelines
 
 Read docs/develop.rst before writing or editing any code or docstrings.
+
+## 6. Attribution
+
+Add a co-author trailer naming yourself to every commit you create:
+
+```
+Co-authored-by: <Tool Name> <email>
+```
+
+Disclose AI assistance in pull request descriptions: which tools were used, how
+they were used, and what is AI generated.
+
+You may draft the text of issues and pull requests. The contributor reviews and
+edits that text before it is submitted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -343,6 +343,18 @@ Sphinx files guidelines:
 Contributing and Releases
 =========================
 
+AI policy
+---------
+
+Follow the `AI Policy of NumPy`_ when writing issues and pull requests,
+with one exception: AI coding tools may be used to draft the text of
+issues and pull requests, not just to translate or edit it.  The
+contributor is responsible for reviewing and editing any drafted text
+before submitting it, and must disclose the AI assistance as described in
+that policy.
+
+.. _AI Policy of NumPy: https://numpy.org/doc/stable/dev/ai_policy.html
+
 Releasing new versions
 ----------------------
 


### PR DESCRIPTION
This is a small PR to add some AI agent coding rules, including following the [NumPy AI policy](https://numpy.org/doc/stable/dev/ai_policy.html).  I did add an exception, which is that it is OK to have the PR drafted by an AI coding tool (since it usually does a good job of summarizing), as long as a human reviews it.
