### PR TITLE
Fix GFP loading comparison by updating mRNA degradation rates + related bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,3 +69,21 @@ they were used, and what is AI generated.
 
 You may draft the text of issues and pull requests. The contributor reviews and
 edits that text before it is submitted.
+
+### Copyright headers
+
+New source files start with:
+
+```
+#  Copyright (c) <current year>, BioCRNpyler Developers. All rights reserved.
+#  See LICENSE file in the project root directory for details.
+```
+
+Use the year the file is created, and the collective name rather than an
+individual or institution - the same convention NumPy and SciPy use
+("NumPy Developers", "SciPy Developers"), which avoids having to revisit
+headers as contributors change.
+
+Leave the headers on existing files alone. Many still name Build-A-Cell and
+carry the year they were written, and rewriting them is churn that buries the
+real change in a diff.

--- a/Tests/Unit/test_parameter_consistency.py
+++ b/Tests/Unit/test_parameter_consistency.py
@@ -1,0 +1,194 @@
+#  Copyright (c) 2026, BioCRNpyler Developers. All rights reserved.
+#  See LICENSE file in the project root directory for details.
+
+"""Consistency checks across the default parameter files.
+
+The same parameter is often declared in several files: a mechanism default
+in `mechanisms/*_parameters.tsv` and again in each `mixtures/*_parameters.tsv`
+that wants a different value.  Nothing keeps those copies in step, so a value
+updated in one file can silently go stale in another.  The tests here pin down
+which divergences are deliberate and check that everything else agrees.
+"""
+
+import glob
+import io
+import os
+from collections import defaultdict
+
+import pytest
+
+import biocrnpyler as bcp
+
+# Parameters that are deliberately different between files, with the reason.
+# Anything else that differs is treated as drift and fails the first test.
+INTENTIONAL_DIVERGENCES = {
+    # Cells lose RNA to growth dilution as well as degradation, so the
+    # one step expression rate is lower than in a cell free extract.
+    ('gene_expression', '', 'kexpress'),
+    # Degradation is faster in vivo than in extract, so both the
+    # Michaelis-Menten constants and the first order rate differ.
+    ('rna_degradation', '', 'kdil'),
+    ('rna_degradation_mm', '', 'kdeg'),
+    ('rna_degradation_mm', '', 'ku'),
+    # Machinery and metabolite levels are properties of the system being
+    # modelled: whole cells, TX-TL extract, and reconstituted PURE each
+    # have their own measurements.
+    ('initial concentration', '', 'ATP'),
+    ('initial concentration', '', 'NTPs'),
+    ('initial concentration', '', 'RNAP'),
+    ('initial concentration', '', 'RNase'),
+    ('initial concentration', '', 'Ribo'),
+}
+
+# Files holding mechanism defaults rather than the settings of one mixture.
+MECHANISM_FILES = {
+    'binding_parameters.tsv',
+    'enzyme_parameters.tsv',
+    'transport_parameters.tsv',
+    'txtl_parameters.tsv',
+}
+
+# Mixtures are exercised with a single constitutively expressed gene.
+MIXTURES = [
+    'ExpressionExtract',
+    'SimpleTxTlExtract',
+    'TxTlExtract',
+    'EnergyTxTlExtract',
+    'PURE',
+    'ExpressionDilutionMixture',
+    'SimpleTxTlDilutionMixture',
+    'TxTlDilutionMixture',
+]
+
+
+def parameter_files():
+    root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    pattern = os.path.join(root, 'biocrnpyler', '**', '*.tsv')
+    return sorted(glob.glob(pattern, recursive=True))
+
+
+def parameters_by_key():
+    """Map (mechanism, part_id, param_name) to {file name: value}."""
+    table = defaultdict(dict)
+    for path in parameter_files():
+        for line in io.open(path, encoding='utf-8'):
+            if line.startswith('#') or not line.strip():
+                continue
+            fields = line.rstrip('\n').split('\t')
+            if len(fields) < 4 or fields[0] in ('mechanism', 'mechanism_id'):
+                continue
+            key = (fields[0], fields[1], fields[2])
+            table[key][os.path.basename(path)] = fields[3]
+    return table
+
+
+def make_gene():
+    return bcp.DNAassembly(
+        name='gfp', promoter='pconst', rbs='rbs_strong', protein='GFP'
+    )
+
+
+def concentration(entry):
+    """Initial concentrations come back as Parameters or as plain numbers."""
+    return float(getattr(entry, 'value', entry))
+
+
+def test_parameter_files_are_readable():
+    # Guards the file based tests, which quietly pass if nothing is parsed
+    table = parameters_by_key()
+    assert len(parameter_files()) >= 5
+    assert len(table) > 50
+
+
+def test_no_unintended_divergence():
+    """Duplicated parameters agree unless the difference is deliberate."""
+    drifted = {}
+    for key, values in parameters_by_key().items():
+        if (
+            len(set(values.values())) > 1
+            and key not in INTENTIONAL_DIVERGENCES
+        ):
+            drifted[key] = values
+    assert not drifted, (
+        "These parameters are declared in several files with different "
+        "values. Either bring them back into agreement, or add the key to "
+        f"INTENTIONAL_DIVERGENCES with a reason: {drifted}"
+    )
+
+
+def test_mechanism_defaults_are_not_stale():
+    """A mechanism default must be a value some mixture actually uses.
+
+    Mixtures on the allowlist are expected to disagree with each other, so
+    that test alone cannot tell a deliberate difference from a mechanism
+    default left behind when the mixtures moved on.  Requiring the default
+    to match at least one mixture catches the stale copy without
+    constraining the mixtures.
+    """
+    stale = {}
+    for key, values in parameters_by_key().items():
+        defaults = {f: v for f, v in values.items() if f in MECHANISM_FILES}
+        used = {v for f, v in values.items() if f not in MECHANISM_FILES}
+        if not defaults or not used:
+            continue
+        for name, value in defaults.items():
+            if value not in used:
+                stale[(key, name)] = (value, sorted(used))
+    assert not stale, (
+        "These mechanism defaults do not match any value a mixture uses, "
+        "which usually means the default was missed when the mixture files "
+        f"were updated: {stale}"
+    )
+
+
+def test_allowlisted_parameters_are_set_explicitly():
+    """A mixture must set any allowlisted parameter its mechanisms use.
+
+    Values on the allowlist are expected to differ per mixture, so relying
+    on a default from another file would silently give the wrong one.
+    """
+    missing = []
+    for name in MIXTURES:
+        mixture = getattr(bcp, name)(name='m', components=[make_gene()])
+        mechanisms = list(mixture.mechanisms.values()) + list(
+            mixture.global_mechanisms.values()
+        )
+        used = {getattr(m, 'name', None) for m in mechanisms}
+        declared = {
+            (key.mechanism, key.part_id or '', key.name)
+            for key in mixture.parameter_database.parameters
+        }
+        for key in sorted(INTENTIONAL_DIVERGENCES):
+            if key[0] in used and key not in declared:
+                missing.append((name, key))
+    assert not missing, (
+        "These mixtures use a mechanism whose parameter is expected to "
+        "differ per mixture, but do not set it in their own parameter "
+        f"file: {missing}"
+    )
+
+
+@pytest.mark.parametrize('name', MIXTURES)
+def test_mixture_compiles_and_expresses(name):
+    """Every mixture builds a CRN that actually makes protein.
+
+    A missing parameter can leave a species at zero rather than raising,
+    so compiling is not on its own evidence that a mixture works.
+    """
+    crn = getattr(bcp, name)(name='m', components=[make_gene()]).compile_crn()
+    assert crn.reactions, f'{name} compiled with no reactions'
+
+    species = {str(s) for s in crn.species}
+    assert 'protein_GFP' in species
+
+    initial = crn.initial_concentration_dict
+    machinery = {
+        str(s): concentration(initial.get(s, 0))
+        for s in crn.species
+        if ('RNAP' in str(s) or 'Ribo' in str(s)) and 'complex' not in str(s)
+    }
+    assert all(v > 0 for v in machinery.values()), (
+        f'{name} leaves machinery at zero concentration: {machinery}'
+    )

--- a/biocrnpyler/mechanisms/txtl.py
+++ b/biocrnpyler/mechanisms/txtl.py
@@ -1225,7 +1225,10 @@ class Transcription_MM(MichaelisMentenCopy):
             raise ValueError("'rnap' parameter must be a Species.")
 
         MichaelisMentenCopy.__init__(
-            self=self, name=name, mechanism_type='transcription'
+            self=self,
+            name=name,
+            mechanism_type='transcription',
+            parameter_file=parameter_file,
         )
 
     def update_species(self, dna, transcript=None, protein=None, **kwargs):
@@ -1450,7 +1453,10 @@ class Translation_MM(MichaelisMentenCopy):
         else:
             raise ValueError("ribosome must be a Species!")
         MichaelisMentenCopy.__init__(
-            self=self, name=name, mechanism_type='translation'
+            self=self,
+            name=name,
+            mechanism_type='translation',
+            parameter_file=parameter_file,
         )
 
     def update_species(self, transcript, protein, **kwargs):

--- a/biocrnpyler/mechanisms/txtl_parameters.tsv
+++ b/biocrnpyler/mechanisms/txtl_parameters.tsv
@@ -10,7 +10,14 @@
 mechanism	part_id	param_name	value	units	comments
 
 # OneStepGeneExpression
-gene_expression		kexpress	19.23	/sec
+#
+# kexpress collapses transcription and translation into a single step,
+# kexpress = ktx * ktl / (RNA loss rate).  With ktx = ktl = 0.05 /sec and
+# the 8.25E-4 /sec mRNA decay measured for TX-TL extract (see
+# mixtures/extract_parameters.tsv), that is 0.05 * 0.05 / 8.25E-4.
+# Mixtures that model a different RNA loss rate set their own value.
+#
+gene_expression		kexpress	3.030	/sec	ktx * ktl / kdil
 
 # SimpleTranscription and SimpleTranslation
 transcription		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt

--- a/biocrnpyler/mechanisms/txtl_parameters.tsv
+++ b/biocrnpyler/mechanisms/txtl_parameters.tsv
@@ -37,12 +37,33 @@ transcription		n	2		cooperativity
 transcription		kleak	0.013	/sec	SK07, Table 1, R37
 
 # Transcription_MM and Translation_MM
+#
+# Transcription uses SK07 R31/R32, which are a binding/unbinding pair:
+#
+#   R31  RNAp + P + OP  -->  RNAp:P:OP        8.6E+06 /M/sec
+#   R32  RNAp:P:OP  -->  RNAp + P + OP        0.01    /sec
+#
+# Translation uses the Singhal values, because SK07 describes ribosome
+# loading with a different reaction scheme:
+#
+#   R45  mRNA + Ribosome  -->  Rib:mRNA       1.0E+05 /M/sec
+#   R46  Rib:mRNA  -->  Rib:mRNA1 + mRNA      100     /sec
+#
+# In R46 the ribosome clears the ribosome binding site to form an
+# elongating complex and releases the mRNA, so that another ribosome can
+# load behind it (polysome formation).  Translation_MM has no separate
+# elongating-complex state, and its 'ku' is a genuine dissociation back to
+# free ribosome and free mRNA - a step SK07 does not model.
+#
+# Note that mixtures/extract_parameters.tsv and mixtures/pure_parameters.tsv
+# set these same parameters and take precedence for those mixtures.
+#
 transcription_mm		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
 transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
 transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 translation_mm		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
-translation_mm		kb	0.1	/uM/sec	SK07, Table 1, R45
-translation_mm		ku	100	/sec	SK07, Table 1, R46
+translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2
+translation_mm		ku	0.003	/sec	Singhal et al. Table S2
 
 # Energy_Transcription_MM and Energy_Translation_MM
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
@@ -53,8 +74,8 @@ energy_transcription_mm		ku_ntps	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA co
 energy_transcription_mm		length	1000	nt	default length of gene (for resource usage)
 
 energy_translation_mm		ktl	15	/sec	15 aa/s (rate will be divided by length)
-energy_translation_mm		kb	0.1	/uM/sec	SK07, Table 1, R45
-energy_translation_mm		ku	100	/sec	SK07, Table 1, R46
+energy_translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2
+energy_translation_mm		ku	0.003	/sec	Singhal et al. Table S2
 energy_translation_mm		kb_fuel	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		ku_fuel	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_translation_mm		length	300	aa	default length of a protein (for resource uasge)

--- a/biocrnpyler/mixtures/cell_parameters.tsv
+++ b/biocrnpyler/mixtures/cell_parameters.tsv
@@ -4,11 +4,33 @@
 # parameters are chosen to match the gene expression rates in E. coli
 # under exponential growth.
 #
+#   [SK07] V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic
+#   Tetracycline-Inducible Regulatory Networks: Computer-Aided Design
+#   of Dynamic Phenotypes."  BMC Systems Biology 1, no. 1 (2007): 7.
+#   https://doi.org/10.1186/1752-0509-1-7.
+#
+#   [MN19] Marshall, Ryan, and Vincent Noireaux. "Quantitative Modeling of
+#   Transcription and Translation of an All-E. coli Cell-Free System".
+#   Scientific Reports 9 (2019):11980.
+#   https://doi.org/10.1038/s41598-019-48468-8.
+#
 mechanism	part_id	param_name	value	units	comments
 
-# Concentration using BioNumbers for E. coli, assuming volume of 1 um^3
+# Expression machinery, converted to concentrations assuming an E. coli
+# volume of 1 um^3.
+#
+#   RNAP   about 3,000 molecules per cell (BioNumbers 106199).
+#
+#   Ribo   MN19 gives 44,000-73,000 ribosomes per cell in rich medium
+#          (20-30 min doubling time), which is 73-121 uM at 1 um^3, and
+#          100 uM sits inside that range.  (BioNumbers 108604 reports
+#          65,000 per um^3, but that is a peak density within
+#          ribosome-rich regions rather than a whole-cell average.)
+#
+#   RNase  about 1,500 molecules per cell (BioNumbers 111532).
+#
 initial concentration	e_coli	RNAP	5	uM	~3,000 RNAP molecules (BioNumbers 106199)
-initial concentration	e_coli	Ribo	100	uM	~65,000 Ribosomes per cell (BioNumbers 108604)
+initial concentration	e_coli	Ribo	100	uM	44,000-73,000 ribosomes/cell (MN19)
 initial concentration	e_coli	RNase	2.5	uM	~1,500 RNase molecules (BioNumbers 111532)
 
 # Transcription and translation rates per unit of "activated" DNA
@@ -19,9 +41,41 @@ translation		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 dilution		kdil	5.78E-4	/sec	half life of ~20 minutes (E. coli doubling time)
 
 # RNA degradation, based on E. coli
-rna_degradation_mm		kdeg	1.3E-4	/sec	degradation rate of bound RNAase (half life of 2 min)
-rna_degradation_mm		kb	1	/sec/uM	binding of RNAase to RNA (fast)
-rna_degradation_mm		ku	1.25E-06	/sec	unbinding of RNAase to RNA (slow)
+#
+# SK07 Table 1 (R44/R90) models mRNA decay as a first order reaction with
+# k = 0.002 /sec, a mean lifetime of 8.3 min.  This agrees with the 9.8 min
+# in vivo figure quoted by TX-TL 2.0 and with BioNumbers 111927 (global
+# half-lives converge at about 5 min).
+#
+# That measured decay rate is k_eff, the effective first order rate at
+# which a transcript disappears (k_eff = 1 / mean lifetime).  The kdeg set
+# below is a different quantity: the Michaelis-Menten catalytic constant
+# (k_cat), related to k_eff by k_eff = kdeg * [RNase] / K_M.
+#
+# The Michaelis-Menten form is set to reproduce that effective rate, using
+# the same K_M = 8 uM convention as MN19: K_M is a modeling choice, picked
+# large enough that degradation stays pseudo-first-order.  See
+# extract_parameters.tsv for the provenance.  Holding kb = 1 /sec/uM
+# and [RNase] = 2.5 uM:
+#
+#   kdeg = k_eff * K_M / [RNase] = 0.002 * 8 / 2.5 = 6.4E-3 /sec
+#   ku   = K_M * kb - kdeg       = 8 - 0.0064      = 7.9936 /sec
+#
+# On kb: K_M is identifiable, kb and ku individually are not.  Binding
+# equilibrates in well under a second against an mRNA lifetime of minutes,
+# so the RNase:mRNA complex sits in quasi-equilibrium and the dynamics
+# depend on kb and ku only through their ratio.
+#
+# kb = 1 /sec/uM is 1E6 /M/sec, the generic protein association rate
+# (BioNumbers 112534, 0.5-5E6 /M/sec, Northrup and Erickson 1992).  There
+# is no measured kon for RNase E on mRNA, so a generic value is used.
+#
+# The one constraint on kb is kb > kdeg / K_M (= 8.0E-4 /sec/uM here),
+# below which ku would have to be negative.
+#
+rna_degradation_mm		kdeg	6.4E-3	/sec	k_cat; k_eff = 0.002 /sec (SK07, R44)
+rna_degradation_mm		kb	1	/sec/uM	generic protein association (BioNumbers 112534)
+rna_degradation_mm		ku	7.9936	/sec	set so K_M = (ku+kdeg)/kb = 8 uM (MN19)
 
 # "Background" usage of resources
 #
@@ -46,5 +100,10 @@ initial concentration	e_coli	cellular_processes	5	uM	~3000 genes in E. coli assu
 #               = kexpress * [DNA] - kdil * [protein]
 #
 # kexpress = ktx * ktl / (kdeg * [RNAse] + kdil)
-# 
-gene_expression		kexpress	1.89	/sec
+#
+# With ktx = ktl = 0.05 /sec, the effective RNA degradation rate k_eff =
+# 0.002 /sec from above, and kdil = 5.78E-4 /sec,
+#
+#   kexpress = 0.05 * 0.05 / (0.002 + 5.78E-4) = 0.970 /sec
+#
+gene_expression		kexpress	0.970	/sec	ktx * ktl / (k_eff + kdil)

--- a/biocrnpyler/mixtures/cell_parameters.tsv
+++ b/biocrnpyler/mixtures/cell_parameters.tsv
@@ -77,6 +77,21 @@ rna_degradation_mm		kdeg	6.4E-3	/sec	k_cat; k_eff = 0.002 /sec (SK07, R44)
 rna_degradation_mm		kb	1	/sec/uM	generic protein association (BioNumbers 112534)
 rna_degradation_mm		ku	7.9936	/sec	set so K_M = (ku+kdeg)/kb = 8 uM (MN19)
 
+# The simple mixtures degrade RNA with a first order Dilution mechanism
+# named 'rna_degradation' instead of the Michaelis-Menten form above, which
+# amounts to assuming a fixed pool of RNase in quasi-equilibrium with the
+# transcript.  Its rate is therefore the steady state rate of the
+# Michaelis-Menten mechanism, k_eff = kdeg * [RNase] / K_M = 0.002 /sec, so
+# that both families of cell mixture lose RNA at the same rate.
+#
+# This is separate from the growth dilution above: in a cell RNA is lost
+# both by degradation and by dilution, so the total first order loss is
+# 0.002 + 5.78E-4 = 2.578E-3 /sec, which is the rate the kexpress below
+# assumes.  Note that the Dilution mechanism used here carries
+# mechanism_type 'dilution', so without an explicit entry the lookup
+# resolves to the growth dilution rate instead.
+rna_degradation		kdil	2.0E-3	/sec	matches k_eff of rna_degradation_mm
+
 # "Background" usage of resources
 #
 # The 'cellular_processes' parameter is used to reflect the utilization of

--- a/biocrnpyler/mixtures/cell_parameters.tsv
+++ b/biocrnpyler/mixtures/cell_parameters.tsv
@@ -19,6 +19,14 @@ mechanism	part_id	param_name	value	units	comments
 # Expression machinery, converted to concentrations assuming an E. coli
 # volume of 1 um^3.
 #
+# These carry no part_id.  Initial concentrations are looked up with
+# part_id set to the mixture's name, so a part_id here would only
+# resolve for a mixture that happened to carry that same name and
+# would silently leave the machinery at zero for any other.  Leaving
+# it blank lets the (mechanism, param_name) tier match whatever the
+# mixture is called; a part_id qualified entry can still be added to
+# override these for one particular mixture name.
+#
 #   RNAP   about 3,000 molecules per cell (BioNumbers 106199).
 #
 #   Ribo   MN19 gives 44,000-73,000 ribosomes per cell in rich medium
@@ -29,9 +37,9 @@ mechanism	part_id	param_name	value	units	comments
 #
 #   RNase  about 1,500 molecules per cell (BioNumbers 111532).
 #
-initial concentration	e_coli	RNAP	5	uM	~3,000 RNAP molecules (BioNumbers 106199)
-initial concentration	e_coli	Ribo	100	uM	44,000-73,000 ribosomes/cell (MN19)
-initial concentration	e_coli	RNase	2.5	uM	~1,500 RNase molecules (BioNumbers 111532)
+initial concentration		RNAP	5	uM	~3,000 RNAP molecules (BioNumbers 106199)
+initial concentration		Ribo	100	uM	44,000-73,000 ribosomes/cell (MN19)
+initial concentration		RNase	2.5	uM	~1,500 RNase molecules (BioNumbers 111532)
 
 # Transcription and translation rates per unit of "activated" DNA
 transcription		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
@@ -101,7 +109,7 @@ rna_degradation		kdil	2.0E-3	/sec	matches k_eff of rna_degradation_mm
 # cell.  The rates of transcription and translation are hard coded into the
 # mixture (and probably need to be changed at some point).
 # 
-initial concentration	e_coli	cellular_processes	5	uM	~3000 genes in E. coli assuming weak loading on all of them
+initial concentration		cellular_processes	5	uM	~3000 genes in E. coli assuming weak loading on all of them
 
 # For simplified gene expression model, we assume that DNA goes directly to
 # protein and so 'kexpress' captures the steady state production rate:

--- a/biocrnpyler/mixtures/extract.py
+++ b/biocrnpyler/mixtures/extract.py
@@ -587,9 +587,15 @@ class TxTlExtract(Mixture):
         # Create default TxTl Mechanisms
         mech_tx = Transcription_MM(rnap=self.rnap.get_species())
         mech_tl = Translation_MM(ribosome=self.ribosome.get_species())
+        # mRNA spends most of its life bound inside the Ribo:mRNA
+        # translation complex, so RNase has to reach it there as well as
+        # free in solution.  Recursive species filtering is what lets the
+        # degradation mechanism act on RNA nested inside a complex: it adds
+        # a reaction pair that degrades the bound transcript and releases
+        # the ribosome.
         mech_rna_deg = Degradation_mRNA_MM(
             nuclease=self.rnase.get_species(),
-            recursive_species_filtering=False,
+            recursive_species_filtering=True,
         )
         mech_cat = MichaelisMenten()
         mech_bind = One_Step_Binding()
@@ -853,9 +859,15 @@ class EnergyTxTlExtract(Mixture):
             + [self.amino_acids.get_species()],
             wastes=4 * [self.adp.get_species()],
         )
+        # mRNA spends most of its life bound inside the Ribo:mRNA
+        # translation complex, so RNase has to reach it there as well as
+        # free in solution.  Recursive species filtering is what lets the
+        # degradation mechanism act on RNA nested inside a complex: it adds
+        # a reaction pair that degrades the bound transcript and releases
+        # the ribosome.
         mech_rna_deg = Degradation_mRNA_MM(
             nuclease=self.rnase.get_species(),
-            recursive_species_filtering=False,
+            recursive_species_filtering=True,
         )
         mech_cat = MichaelisMenten()
         mech_bind = One_Step_Binding()

--- a/biocrnpyler/mixtures/extract_parameters.tsv
+++ b/biocrnpyler/mixtures/extract_parameters.tsv
@@ -14,6 +14,11 @@
 #   Systems". Synthetic Biology 6, no. 1 (2021):ysab007.
 #   https://doi.org/10.1093/synbio/ysab007.
 #
+#   [MN19] Marshall, Ryan, and Vincent Noireaux. "Quantitative Modeling of
+#   Transcription and Translation of an All-E. coli Cell-Free System".
+#   Scientific Reports 9 (2019):11980.
+#   https://doi.org/10.1038/s41598-019-48468-8.
+#
 # The parameters for the most complex mechanisms are listed first, with
 # subsequent parameters chosen to be consistent with those values.
 #
@@ -31,9 +36,31 @@ mechanism	part_id	param_name	value	units	comments
 # EnergyTxTlExtract explicitly tracks NTPs, amino acids, and fuel species
 # (e.g., 3PGA for ATP regeneration).
 
-# Cell expression machinery: parameters are chosen at 1/10 E. coli
-initial concentration		RNAP	0.5	uM	1/10 RNAP from cell_parameters.tsv
-initial concentration		Ribo	10	uM	1/10 Ribo from cell_parameters.tsv
+# Cell expression machinery.
+#
+# The dilution from cytoplasm to TXTL reaction is not a single factor: it
+# depends on how much of each species survives lysis and extract
+# preparation.  MN19 works the numbers through for the two species that
+# have been quantified, so those are used directly, and only RNase falls
+# back on the 1/10 rule of thumb.
+#
+#   RNAP  MN19 puts the maximum at 500 nM of core RNA polymerase in a TXTL
+#         reaction if every enzyme is released, and best fits 400 nM.  The
+#         0.5 uM below is that upper bound, which is also 1/10 of the
+#         cell value.
+#
+#   Ribo  MN19 estimates 1450-2500 nM of total ribosomes in a TXTL reaction
+#         and best fits Rtot = 1100 nM of *active* ribosomes.  Translation_MM
+#         is structurally the same model (ribosome binds mRNA, MM kinetics),
+#         so the active figure is the comparable one.  This is roughly
+#         1/90 of the cell value.
+#
+#   RNase no measurement in extract, so kept at 1/10 of the cell value.  The
+#         kdeg derived below absorbs this uncertainty: k_eff is what is
+#         pinned to data, and kdeg scales inversely with [RNase].
+#
+initial concentration		RNAP	0.5	uM	MN19 max for a TXTL reaction
+initial concentration		Ribo	1.1	uM	MN19 Rtot, active ribosomes in TXTL
 initial concentration		RNase	0.25	uM	1/10 RNAse from cell_parameters.tsv
 
 initial concentration		ATP	600	uM	TX-TL 2.0: [ATP/GTP] - [CTP/UTP]
@@ -98,11 +125,66 @@ translation		ktl	0.05	/sec	15 aa/s and protein length of 300 aa
 # Global Mechanisms
 #
 
-# RNA degradation, based on E. coli (see cell_parameters.tsv)
-rna_degradation_mm		kdeg	1.3E-4	/sec	degradation rate of bound RNAase (half life of 2 min)
-rna_degradation		kdil	1.3E-4	/sec	implemented as 'dilution' for SimpleTxTlExtract
-rna_degradation_mm		kb	1	/sec/uM	binding of RNAase to RNA (fast)
-rna_degradation_mm		ku	1.25E-06	/sec	unbinding of RNAase to RNA (slow)
+# RNA degradation, measured in the TX-TL extract itself.
+#
+# MN19 determined the deGFP mRNA degradation rate by assay (their Fig. S4):
+# kdeg,m = 8.25E-4 /sec, a mean lifetime of 20.2 min.  TX-TL 2.0 measures
+# the same transcript by a transcription-arrest assay and reports 17.45 min
+# with no MazF added (against 9.8 min in E. coli), so the two independent
+# measurements bracket a fairly narrow range.  MN19's value is used here
+# because it is the one paired with the K_M convention adopted below.
+#
+# k_eff is the effective first order decay rate of mRNA: the single
+# constant describing how fast a transcript disappears, related to the
+# mean lifetime by k_eff = 1 / lifetime.  It is the quantity the assays
+# above measure, and the one MN19 call kdeg,m.  The kdeg set further down
+# in this file is a different quantity: the Michaelis-Menten catalytic
+# constant (k_cat) for the bound RNase:mRNA complex.
+#
+# When [mRNA] is well below K_M the Michaelis-Menten rate law reduces to
+# first order decay, and the two are related by
+#
+#   k_eff = kdeg * [RNase] / K_M,   K_M = (ku + kdeg) / kb
+#
+# K_M here is a modeling convention rather than a measured quantity.
+# MN19 write the degradation term as k[RNase][m]/(K_M,m + [m]) and say the
+# constants kd,m (6.6 nM/s) and K_M,m (8000 nM) "were chosen so as to
+# obtain kdeg,m determined by the assay": K_M is picked large compared
+# with [mRNA] (a few nM) so that the Michaelis-Menten form reduces to the
+# pseudo-first-order decay they measured.  The same convention is used
+# here, so k_eff is the quantity pinned to data and K_M = 8 uM carries
+# over from MN19 to keep degradation out of saturation.
+#
+# Holding kb = 1 /sec/uM and [RNase] = 0.25 uM then fixes kdeg and ku:
+#
+#   kdeg = k_eff * K_M / [RNase] = 8.25E-4 * 8 / 0.25 = 2.64E-2 /sec
+#   ku   = K_M * kb - kdeg       = 8 - 0.0264          = 7.9736 /sec
+#
+# On kb: K_M is identifiable, kb and ku individually are not.  Binding
+# equilibrates in well under a second against an mRNA lifetime of tens of
+# minutes, so the RNase:mRNA complex sits in quasi-equilibrium and the
+# dynamics depend on kb and ku only through their ratio.  Holding
+# K_M = 8 uM, any kb between 0.01 and 100 /sec/uM gives the same mRNA
+# lifetime and the same steady-state protein to within 0.1%.
+#
+# kb = 1 /sec/uM is 1E6 /M/sec, the generic protein association rate
+# (BioNumbers 112534, 0.5-5E6 /M/sec, Northrup and Erickson 1992).  There
+# is no measured kon for RNase E on mRNA, so a generic value is used.
+#
+# The one constraint on kb is kb > kdeg / K_M (= 3.3E-3 /sec/uM here),
+# below which ku would have to be negative.
+#
+# kdil is the same measured rate in plain first order form, used by
+# SimpleTxTlExtract, which has no explicit RNase.
+#
+# This reproduces MN19 exactly: their kd,m is a V_max directly comparable
+# to kdeg * [RNase] here, and 2.64E-2 * 0.25 uM = 6.60 nM/s against their
+# stated 6.6 nM/s.
+#
+rna_degradation_mm		kdeg	2.64E-2	/sec	k_cat; 20.2 min mean lifetime (MN19)
+rna_degradation		kdil	8.25E-4	/sec	20.2 min mean lifetime (MN19)
+rna_degradation_mm		kb	1	/sec/uM	generic protein association (BioNumbers 112534)
+rna_degradation_mm		ku	7.9736	/sec	set so K_M = (ku+kdeg)/kb = 8 uM (MN19)
 
 #
 # ExpressionExtract
@@ -119,5 +201,10 @@ rna_degradation_mm		ku	1.25E-06	/sec	unbinding of RNAase to RNA (slow)
 #               = kexpress * [DNA]
 #
 # kexpress = ktx * ktl / kdeg
-# 
-gene_expression		kexpress	19.23	/sec
+#
+# With ktx = ktl = 0.05 /sec and the first order rate kdil = 8.25E-4 /sec
+# from the RNA degradation section above,
+#
+#   kexpress = 0.05 * 0.05 / 8.25E-4 = 3.030 /sec
+#
+gene_expression		kexpress	3.030	/sec	ktx * ktl / kdil

--- a/biocrnpyler/mixtures/extract_parameters.tsv
+++ b/biocrnpyler/mixtures/extract_parameters.tsv
@@ -69,8 +69,8 @@ initial concentration		amino_acids	6.0E4	uM	TX-TL 2.0 3 mM (upper bound) * 20 AA
 initial concentration		Fuel_3PGA	3.0E4	uM	TX-TL 2.0: 30 mM
 
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
-energy_transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{F, lac}
-energy_transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+energy_transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
+energy_transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 energy_transcription_mm		kb_ntps	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		ku_ntps	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		length	1000	nt	default length of gene (for resource usage)
@@ -97,8 +97,8 @@ one_step_pathway	ATP_degradation	k	0.0000177	/sec	Delta_ATP, Singhal et al. Tabl
 
 # Default binding/unbinding rates for promoters
 transcription_mm		ktx	0.05	/sec	50 nt/s and transcript length of 1000 nt
-transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{F, lac}
-transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
+transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 
 # Default binding/unbinding rates for RBS
 translation_mm		ktl	0.05	/sec	15 aa/s and protein length of 300 aa

--- a/biocrnpyler/mixtures/pure.py
+++ b/biocrnpyler/mixtures/pure.py
@@ -108,6 +108,19 @@ class PURE(Mixture):
     - 'binding' : `One_Step_Binding` - Simple multi-species binding for
       forming complexes
 
+    Unlike the extract mixtures, no 'rna_degradation' mechanism is included.
+    PURE is reconstituted from purified components and carries no
+    ribonucleases, and the detailed PURE reaction network of Jurado, Pandey
+    and Murray (2023) has no mRNA degradation step either; their MGapt
+    measurements show transcript continuing to accumulate past two hours.
+    Apparent decay of the MGapt signal in commercial PURE is a property of
+    the dye chemistry rather than of the mRNA (Jurado and Murray, 2024).
+
+    A consequence is that mRNA accumulates for the length of the
+    simulation and progressively binds ribosomes.  That is intended: once
+    ATP is exhausted the ribosomes stall on transcript they can no longer
+    translate.
+
     Key features of this mixture:
 
     - Explicit modeling of PURE system components

--- a/biocrnpyler/mixtures/pure_parameters.tsv
+++ b/biocrnpyler/mixtures/pure_parameters.tsv
@@ -5,6 +5,23 @@
 #
 # https://nucleus.bnext.bio/Base-PURE-Guide-0991591e9f474a5bbc934dc141503ae2
 #
+# Rate constants not fixed by that protocol come from:
+#
+#   [SK07] V. Sotiropoulos and Y. N. Kaznessis.  "Synthetic
+#   Tetracycline-Inducible Regulatory Networks: Computer-Aided Design
+#   of Dynamic Phenotypes."  BMC Systems Biology 1, no. 1 (2007): 7.
+#   https://doi.org/10.1186/1752-0509-1-7.
+#
+# There are deliberately no rna_degradation parameters here.  PURE is
+# reconstituted from purified components and carries no ribonucleases, so
+# the mixture includes no RNA degradation mechanism to parameterise.  The
+# detailed PURE reaction network in Jurado, Pandey and Murray, "A chemical
+# reaction network model of PURE" (2023, doi:10.1101/2023.08.14.553301)
+# likewise has no mRNA degradation step, and their MGapt measurements show
+# transcript still accumulating past two hours.  Jurado and Murray (2024,
+# doi:10.1101/2024.03.15.585317) attribute loss of MGapt signal in
+# commercial PURE to the dye chemistry rather than to mRNA decay.
+#
 mechanism	part_id	param_name	value	units	comments
 
 #
@@ -39,15 +56,15 @@ initial concentration		ATP	1000	uM	[ATP/GTP] - [CTP/UTP]
 initial concentration		NTPs	4000	uM	[CTP/UTP] * 4 (NTPs)
 initial concentration		AAs	6000	uM	0.3 mM (upper bound) * 20 AAs
 
-transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{Flac}
-transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
+transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 
 translation_mm		kb	0.819	/uM/sec	Singhal et al. Table S2
 translation_mm		ku	0.003	/sec	Singhal et al. Table S2
 
 energy_transcription_mm		ktx	50	/sec	50 nt/s (rate will be divided by length)
-energy_transcription_mm		kb	4.48	/uM/sec	txtlsim S3: pol_{Flac}
-energy_transcription_mm		ku	2.5E-06	/sec	default_parameters.txt; source unclear (TODO)
+energy_transcription_mm		kb	8.6	/uM/sec	SK07, Table 1, R31
+energy_transcription_mm		ku	0.01	/sec	SK07, Table 1, R32
 energy_transcription_mm		kb_ntps	10	/uM/sec	fast binding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		ku_ntps	1e-6	/sec	slow unbinding of NTPs to RNAP:DNA complex (TODO)
 energy_transcription_mm		length	1000	nt	default length of gene (for resource usage)

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -165,7 +165,9 @@ cfp_simple_res = cfp_simple_crn.simulate_with_bioscrape_via_sbml(
     timepts, initial_condition_dict=cfp_initial_conditions
 )
 
-# Regular mixture should have lower expression, but not limits
+# Regular mixture shares RNAP, ribosomes and RNase across both genes,
+# but at 1 nM DNA none of those pools is anywhere near limiting, so
+# GFP should be essentially unchanged
 cfp_regular_mixture = bcp.TxTlExtract(
     name='energy',
     components=[gfp_dna, cfp_dna],

--- a/examples/gfp_expression.py
+++ b/examples/gfp_expression.py
@@ -139,17 +139,47 @@ plt.ylabel("Concentration [mM]")
 plt.legend()
 
 #
-# Comparison of extract-based expression mixtures
+# Effect of a competing gene on the extract mixtures
+#
+# Figures 1-3 use 1 nM of DNA, where none of the machinery pools in
+# TxTlExtract is close to limiting.  mRNA settles at roughly ktx/kdil = 60
+# times the DNA concentration, so 1 nM of DNA yields only tens of nM of
+# transcript against 1.1 uM of ribosomes, and a second gene changes
+# nothing.  Raising both genes to 10 nM brings the transcript pool within
+# reach of the ribosomes and separates the three mixtures:
+#
+#   simple   models no machinery at all, so the load is invisible
+#   regular  shares ribosomes between the genes, so GFP drops
+#   energy   has a fixed metabolite pool, so the two genes split it evenly
+#
+# The absolute yields are worth as much attention as the ratios.  Without
+# an energy model the extracts run to hundreds of uM, far past what a real
+# TX-TL reaction reaches, while the energy mixture saturates at a
+# realistic level.  The vertical axis is truncated so that the energy
+# traces stay readable, so final values are quoted in the legend.
 #
 plt.figure(4)
 plt.clf()
 
-cfp_initial_conditions = initial_conditions.copy()
-cfp_initial_conditions['dna_cfp'] = 1 * nM
+load_conc = 10 * nM
+load_conditions = {'dna_gfp': load_conc}
+load_cfp_conditions = {'dna_gfp': load_conc, 'dna_cfp': load_conc}
 
 # Add some additional DNA that will utilize resources
 cfp_dna = bcp.DNAassembly(
     name='cfp', promoter='pconst', rbs='rbs_strong', protein='CFP'
+)
+
+# Re-run the single gene mixtures at the higher DNA concentration, so that
+# the only difference within each pair below is the presence of CFP
+simple_load_res = simple_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=load_conditions
+)
+regular_load_res = regular_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=load_conditions
+)
+energy_load_res = energy_crn.simulate_with_bioscrape_via_sbml(
+    timepts, initial_condition_dict=load_conditions
 )
 
 # Simple mixture should not be affected
@@ -162,12 +192,11 @@ cfp_simple_mixture = bcp.SimpleTxTlExtract(
 )
 cfp_simple_crn = cfp_simple_mixture.compile_crn()
 cfp_simple_res = cfp_simple_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    timepts, initial_condition_dict=load_cfp_conditions
 )
 
-# Regular mixture shares RNAP, ribosomes and RNase across both genes,
-# but at 1 nM DNA none of those pools is anywhere near limiting, so
-# GFP should be essentially unchanged
+# Regular mixture shares RNAP, ribosomes and RNase across both genes, and
+# at 10 nM the ribosomes are loaded enough for that to cost GFP
 cfp_regular_mixture = bcp.TxTlExtract(
     name='energy',
     components=[gfp_dna, cfp_dna],
@@ -177,10 +206,11 @@ cfp_regular_mixture = bcp.TxTlExtract(
 )
 cfp_regular_crn = cfp_regular_mixture.compile_crn()
 cfp_regular_res = cfp_regular_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    timepts, initial_condition_dict=load_cfp_conditions
 )
 
-# Energy mixture should have lower expression, earlier saturation
+# Energy mixture caps on its metabolite pool rather than on DNA, so two
+# genes of equal strength split that pool and GFP halves
 cfp_energy_mixture = bcp.EnergyTxTlExtract(
     name='energy',
     components=[gfp_dna, cfp_dna],
@@ -190,43 +220,42 @@ cfp_energy_mixture = bcp.EnergyTxTlExtract(
 )
 cfp_energy_crn = cfp_energy_mixture.compile_crn()
 cfp_energy_res = cfp_energy_crn.simulate_with_bioscrape_via_sbml(
-    timepts, initial_condition_dict=cfp_initial_conditions
+    timepts, initial_condition_dict=load_cfp_conditions
 )
 
-lines = plt.plot(
-    timepts / min, simple_res['protein_GFP'] / uM, '--', label='GFP, simple'
-)
-plt.plot(
-    timepts / min,
-    cfp_simple_res['protein_GFP'] / uM,
-    color=lines[0].get_color(),
-    label='GFP, simple w/ CFP',
-)
 
-lines = plt.plot(
-    timepts / min, regular_res['protein_GFP'] / uM, '--', label='GFP, regular'
-)
-plt.plot(
-    timepts / min,
-    cfp_regular_res['protein_GFP'] / uM,
-    color=lines[0].get_color(),
-    label='GFP, regular w/ CFP',
-)
+def plot_cfp_pair(alone_res, cfp_res, label):
+    """Plot GFP with and without CFP, quoting the final value of each."""
+    alone = alone_res['protein_GFP'] / uM
+    loaded = cfp_res['protein_GFP'] / uM
+    final_alone = alone.to_numpy()[-1]
+    final_loaded = loaded.to_numpy()[-1]
+    lines = plt.plot(
+        timepts / min,
+        alone,
+        '--',
+        label=f'GFP, {label} ({final_alone:.0f} uM)',
+    )
+    plt.plot(
+        timepts / min,
+        loaded,
+        color=lines[0].get_color(),
+        label=(
+            f'GFP, {label} w/ CFP ({final_loaded:.0f} uM, '
+            f'{final_loaded / final_alone:.2f}x)'
+        ),
+    )
 
-lines = plt.plot(
-    timepts / min, energy_res['protein_GFP'] / uM, '--', label='GFP, energy'
-)
-plt.plot(
-    timepts / min,
-    cfp_energy_res['protein_GFP'] / uM,
-    color=lines[0].get_color(),
-    label='GFP, energy w/ CFP',
-)
 
-plt.title("Extract Mixture Comparisions w/ CFP")
+plot_cfp_pair(simple_load_res, cfp_simple_res, 'simple')
+plot_cfp_pair(regular_load_res, cfp_regular_res, 'regular')
+plot_cfp_pair(energy_load_res, cfp_energy_res, 'energy')
+
+plt.ylim(0, 200)
+plt.title("Extract Mixture Comparisions w/ CFP (10 nM each)")
 plt.xlabel("Time [min]")
 plt.ylabel("Concentration [uM]")
-plt.legend()
+plt.legend(fontsize=8)
 
 #
 # Comparison with PURE
@@ -259,6 +288,9 @@ plt.legend()
 #
 
 pure_timepts = np.linspace(0, 180 * min)
+
+# The PURE comparisons below use 1 nM of each gene
+cfp_initial_conditions = {'dna_gfp': 1 * nM, 'dna_cfp': 1 * nM}
 
 simple_mixture = bcp.PURE(
     name='simple', components=[gfp_dna, cfp_dna],


### PR DESCRIPTION
This PR fixes a problem that was showing up in `examples/gfp_expression.py` in which the expression level for GFP was going _up_ when competing CFP DNA was added, rather than down (due to resource loading).  In chasing down the bug (with help from Claude Opus), it turns out that the RNase parameters were incorrect and the result was that adding CFP DNA soaked up some of the excess RNAse and so GFP expression rose (so there was loading, just not on the expected resources).

This PR fixes that problem by updating the mRNA degradation parameters to more realistic values (from the literature).

The GFP/CFP fix exposed a series of additional bugs in the way that default parameter files were being included in various mechanisms, so those are included here as well (possibly better as a separate PR, but everything is linked together, so proposing this as one).

## Fix 1: Set mRNA degradation parameters from measured TX-TL lifetimes

In `examples/gfp_expression.py`, figure 4 adds a competing gene (CFP) to show
resource competition. It showed the opposite: adding CFP *raised* per-gene GFP (dashed = GFP only, solid = GFP + CFP):

<img width="640" height="480" alt="Figure_4_old" src="https://github.com/user-attachments/assets/4dd4ea11-6e11-4eb7-938a-b670400f361b" />

The blue curves (on top of each other) are as expected, since the `SimpleTxTlExtract` doesn't include any resource limits.  The green curves (`EnergyTxTlExtract`) also work: energy usage is higher with CFP, so we get less GFP.  But the orange curves (`TxTlExtract`) didn't make sense: GFP expression is _higher_ (by 2X!) with CFP DNA added.

The cause was in the RNase parameters. With `kb = 1 /sec/uM`, `ku = 1.25E-6 /sec` and `kdeg = 1.3E-4 /sec`, the Michaelis constant is

    K_M = (ku + kdeg) / kb = 0.13 nM

against an mRNA pool of a few nM, so RNase was 15-150x saturated and behaved as a near-stoichiometric sink rather than a catalyst: only 6% of it was free with a single gene. Adding a second gene starved degradation further, extending every transcript's lifetime, so per-gene GFP expression went _up_.

Fixing this involved a sequence of changes:

### Degradation rates are now pinned to measurements

The values for `kdeg` and `K_M` are now set using `k_eff`, which is the effective rate of mRNA degradation:

| | value | source |
|---|---|---|
| extract | `k_eff = 8.25E-4 /sec` (20.2 min mean lifetime) | MN19, determined by assay (Fig. S4) |
| cell | `k_eff = 0.002 /sec` (8.3 min) | SK07 Table 1, R44/R90 |

(SK07 = Sotiropoulos and Kaznessis, 2007.) TX-TL 2.0 measures 17.45 min for the same transcript MN19 measures at 20.2 min, so two independent measurements bracket a narrow range.

Only `k_eff` is fixed by data. Depending on the mechanism, other values also need to be determined.

For the Michaelis-Menten model,`K_M = 8 uM` is carried over from MN19 as a modeling convention — they state the constants "were chosen so as to obtain kdeg,m determined by the assay" — and `kdeg` follows from `k_eff`, `K_M` and `[RNase]`. This reproduces MN19's V_max exactly: `2.64E-2 * 0.25 uM = 6.60 nM/s` against their stated `6.6 nM/s`.

For the explicit RNase mechanism, we have to include binding and unbinding.  `kb` is not separately identifiable: binding equilibrates in well under a second against an mRNA lifetime of tens of minutes, so only the ratio matters. Holding `K_M` fixed, any `kb` from 0.01 to 100 /sec/uM gives the same lifetime and the same steady-state protein to within 0.1%. It is now documented as the generic protein association rate (BioNumbers 112534) rather than left uncited.

### Fix ribosome concentration in extract: 10 uM -> 1.1 uM

MN19 best-fits `Rtot = 1100 nM` for active ribosomes in a TXTL reaction, and estimates 1450-2500 nM total. The cytoplasm-to-reaction dilution is not a single factor, so each machinery species now records its own basis rather than a uniform 1/10 rule. RNAP stays at 0.5 uM, which is MN19's stated maximum and coincidentally also 1/10 of the cell value.

### Ribosome-bound mRNA is now degradable

`TxTlExtract` and `EnergyTxTlExtract` passed `recursive_species_filtering=False` to `Degradation_mRNA_MM`, which exempts mRNA inside the Ribo:mRNA complex from degradation entirely. Since mRNA spends most of its life in that complex, RNase could not reach it. Enabling recursive filtering adds one species and two reactions, with no nested RNase:RNase regress, and makes the mRNA lifetime insensitive to the ribosome dissociation constant rather than dependent on it. Interesting, the docstrings had already indicated the bound mRNA was also degraded, but the mixtures did not actually support that.

### Translation constants

The unbinding rate of ribosomes to mRNA for `translation_mm` and `energy_translation_mm` had been set to values from SK07, but they were using the wrong constants.  In particular, SK07 R46 was being used as the reference.  This reaction is

    Rib:mRNA --> Rib:mRNA1 + mRNA      100 /sec

which is the ribosome clearing the binding site to form an elongating complex and releasing the mRNA for the next ribosome (polysome loading), _not_ dissociation. SK07 has no unproductive-dissociation step, so it supplies no `ku` for `Translation_MM`. These values were overridden by the mixture parameter files, so this is not a behavior change — but reading R46 as `ku` weakens the complex ~270,000x, and anyone "fixing" the shadowing (e.g, specifying a new parameter file that didn't set 'ku') would have collapsed protein yield.

RNAP binding in the various parameter files is now harmonized to SK07 R31/R32 (`kb = 8.6`, `ku = 0.01`) across extract and PURE, replacing `ku = 2.5E-06` marked "source unclear (TODO)". R31/R32 *are* a genuine binding/unbinding pair. RNAP is in large excess over DNA in every mixture, so `TxTlExtract` moves 0.8%, everything else under 0.001%.

## Fix 2: Four additional issues found along the way

In chasing this down, a number of other issues came to light:

**Updated `kexpress`.** For one step gene expression,`kexpress` is derived (`ktx * ktl / RNA loss rate`) and is declared in three files. These needed to be updated to reflect the the new degradation rates. Mixtures override it, so nothing misbehaved.

**`cell_parameters.tsv` had no `rna_degradation` entry.** `SimpleTxTlDilutionMixture` degrades RNA with a `Dilution` mechanism *named* `rna_degradation`, but that instance carries `mechanism_type = 'dilution'` whatever it is named, so the `(mechanism_type, part_id, param)` tier matched the growth dilution rate. RNA was removed twice at 5.78E-4 /sec instead of degradation plus dilution. That is a well-formed hit rather than a fallback, so no warning was raised. `kexpress` in the same file already assumed the correct total of 2.578E-3, so the file was internally inconsistent by 2.2x.

**`Transcription_MM` and `Translation_MM` dropped `parameter_file`.** Both accept `parameter_file='mechanisms/txtl_parameters.tsv'` but never passed it to `MichaelisMentenCopy.__init__`, so the parent fell back to `enzyme_parameters.tsv` and the txtl defaults were never read. Those catalysis defaults are unreachable from these classes anyway — lookups go through `mechanism=self`, so only `transcription_mm`/`transcription` keys can match. A scan confirmed these were the only two mechanisms in the codebase with this bug; the other 20 all forward correctly.

**Cell machinery was declared with `part_id='e_coli'`.** Initial concentrations are looked up with `part_id` set to the mixture's own name, so those entries only resolved for a mixture literally named `e_coli`. The cell mixtures default to `name=''`, so the machinery stayed at zero and no protein was expressed, with no warning — falling through to zero is the normal path for an undeclared species. `e_coli` appears nowhere in the Python source.  This was fixed by removing `e_coli` from the parameter file (so it matches generically unless a parameter with a more specific `part_id` is provided.

The last two compounded: `TxTlDilutionMixture` orginally could not compile at all, and once it could, it expressed nothing. It has been unusable for some time, and nothing in the test suite noticed.

## Fix 3: Tests to stop these issues from recurring

Unit tests were added to exposre the bugs above.  In addition `Tests/Unit/test_parameter_consistency.py` adds four checks:

* duplicated parameters must agree unless the key is allowlisted with a reason (nine keys, covering degradation rates and machinery levels that genuinely differ between cells, extract and PURE);
* a mechanism default must match a value some mixture actually uses — the allowlist alone permits mixtures to disagree, which would otherwise hide a stale default, and this is what the `kexpress` bug was;
* a mixture using a mechanism whose parameter is allowlisted must set that parameter in its own file;
* every mixture compiles to a CRN with a protein species and non-zero machinery, since a missing parameter can leave a species at zero rather than raising.

Run against the commits that introduced the fixes, they fail at `771cd33` (four failures), `245cce4` (two), `aa53305` and `ae96fba` (one each), and pass at `b71a8a0`. Every defect above is caught at the commit before its fix.

## Fix 5: `gfp_expression.py` extract comparisons

Coming back to the starting point for this entire branch, the point of Figure 4 in `gfp_expression.py` was to show the differences between the different mixtures.  Originally GFP and CFP were both at 1 nM concentration, which wasn't enough to distinguish between `SimpleTxTl` and 'TxTlExtract` since there were no loading effects.

By raised the DNA concentration to 10 nM per gene, where the ribosome pool actually becomes limiting, it was possible to separate out the expression levels from the different mixtures:

| | alone | w/ CFP | |
|---|---|---|---|
| simple | 618 | 618 uM | 1.00x — models no machinery, load invisible |
| regular | 575 | 482 uM | 0.84x — ribosomes shared |
| energy | 25 | 13 uM | 0.50x — fixed metabolite pool split evenly |

Two corrections were also needed for the comparison to mean anything: the dashed "alone" traces reused results simulated at 1 nM, and the PURE section shares the `cfp_initial_conditions` variable. Figures 1-3 stay at 1 nM, since they compare mixtures at a realistic plasmid concentration while figure 4 deliberately pushes into the resource-limited regime. The vertical axis is truncated at 200 uM so the energy traces stay readable, with final values quoted in the legend.

Here's what all of that did in terms of the plots that started this whole adventure (note flip in line style, which I thought looked better):
<img width="640" height="480" alt="Figure_4_new" src="https://github.com/user-attachments/assets/830967c8-0330-441a-8c57-d6db9e45df63" />

## Fix 6: PURE documentation

This also seemed like a good time to confirm that there were no similar issues in the PURE mixture(s).

PURE keeps no RNA degradation mechanism, and the reasoning is now recorded rather than left implicit. PURE is reconstituted from purified components and carries no ribonucleases. The detailed PURE reaction network of Jurado, Pandey and Murray (2023) has no mRNA degradation step either, and their MGapt measurements show transcript still accumulating past two hours; Jurado and Murray (2024) attribute loss of MGapt signal in commercial PURE to the dye chemistry rather than to mRNA decay. No quantitative mRNA half-life for PURE appears in the literature, so no rate is invented.

The consequence — mRNA accumulating and progressively binding ribosomes — is intended: once ATP is exhausted the ribosomes stall on transcript they can no longer translate. This is now noted in the PURE docstring.

PURE's concentrations are deliberately unchanged. RNAP at 1.3 uM, Ribo at 3 uM and the metabolite levels come from the Nucleus and OnePot PURE protocols, which are separate sources from the TX-TL extract measurements.

## Open issues

* One pre-existing `ODEintWarning` from the energy mixture at 10 nM. Checked against an independent tight LSODA solve: 12.74443 uM against 12.74443 uM, so it is cosmetic, and it is left in place.
* Pre-existing in `examples/gfp_expression.py` on main: an unused `sec` import (ruff F401) and a `ruff format` divergence in the PURE plotting section. `ruff format` wants to change none of the lines added here.
* 23 parameters remain duplicated across files with identical values. They are in sync and the new tests will catch it if they drift, but the underlying redundancy is unchanged.

## AI assistance disclosure

This PR was drafted with Claude Code (Claude Opus 5) working interactively with @murrayrm.

The AI was used to: locate the saturated-RNase root cause and the four subsequent defects; retrieve and convert the literature values (Garamella 2016, Marshall & Noireaux 2019, Sotiropoulos & Kaznessis 2007, Jurado/Pandey/Murray 2023, Jurado/Murray 2024, BioNumbers 108604/111532/111927/112534); run the parameter sweeps, identifiability, convergence and regression checks quoted above; and draft the parameter-file comments, the new tests, the commit messages and this description.

All parameter values, the choice of which measured lifetime to standardise on, and the modeling decisions were directed and reviewed by @murrayrm. Every numerical claim above was produced by a simulation or an arithmetic check rather than asserted.